### PR TITLE
Empezar a usar cuatrimestres absolutos, que modifiquen la disposicion del map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "0.1.0",
       "dependencies": {
         "@chakra-ui/icons": "^1.0.1",
-        "@chakra-ui/react": "^1.3.0",
+        "@chakra-ui/react": "^1.8.6",
         "@emotion/react": "^11.0.0",
         "@emotion/styled": "^11.0.0",
-        "framer-motion": "^2.9.5",
+        "framer-motion": "^4.1.17",
         "react": "^16.13.1",
         "react-dom": "^16.13.1",
         "react-graph-vis": "^1.0.7",
@@ -1377,11 +1377,14 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.11.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-      "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+      "version": "7.17.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
+      "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/runtime-corejs3": {
@@ -1430,27 +1433,29 @@
       }
     },
     "node_modules/@chakra-ui/accordion": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/accordion/-/accordion-1.1.3.tgz",
-      "integrity": "sha512-if61BesRBHK5kmqfS0FesTtsmoYcpSYdgcn2cQ0nk9vEc2RvK6H8FTPlFvu64ycpbD73sa9unpdNdxTtzZp7bw==",
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/accordion/-/accordion-1.4.9.tgz",
+      "integrity": "sha512-ZrfrLwAu6p9B41sZ+iEWjfPW/mn2TdUDXv165qr1O355619e2Btjb01x3IYoN4GlE2iF7GOVjC5uYGNyLpBlZg==",
       "dependencies": {
-        "@chakra-ui/descendant": "1.0.8",
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/icon": "1.1.2",
-        "@chakra-ui/transition": "1.0.9",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/descendant": "2.1.3",
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/icon": "2.0.5",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/transition": "1.4.7",
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
+        "framer-motion": "3.x || 4.x || 5.x || 6.x",
         "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/accordion/node_modules/@chakra-ui/icon": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-1.1.2.tgz",
-      "integrity": "sha512-Gp/G0CZ8X8RWJWrs8jUm1dfA+5lS4zgNd078zQAj+yppnyhRGEGuZ6jAVJowtF+gbljZttmZwfXUgV3WpKnT/A==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-2.0.5.tgz",
+      "integrity": "sha512-ZrqRvCCIxGr4qFd/r1pmtd9tobRmv8KAxV7ygFoc/t4vOSKTcVIjhE12gsI3FzgvXM15ZFVwsxa1zodwgo5neQ==",
       "dependencies": {
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -1458,26 +1463,24 @@
       }
     },
     "node_modules/@chakra-ui/accordion/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/alert": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/alert/-/alert-1.1.2.tgz",
-      "integrity": "sha512-paJyY9S7EvYPZVqpvP3EyzzqXRRQDsEbR62ohfpFQg6C5+S5YWgjos/0YJNPEHDDj/XSQ/4RuAis78CcfivzwQ==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/alert/-/alert-1.3.7.tgz",
+      "integrity": "sha512-fFpJYBpHOIK/BX4BVl/xafYiDBUW+Bq/gUYDOo4iAiO4vHgxo74oa+yOwSRNlNjAgIX7pi2ridsYQALKyWyxxQ==",
       "dependencies": {
-        "@chakra-ui/icon": "1.1.2",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/icon": "2.0.5",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -1485,11 +1488,11 @@
       }
     },
     "node_modules/@chakra-ui/alert/node_modules/@chakra-ui/icon": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-1.1.2.tgz",
-      "integrity": "sha512-Gp/G0CZ8X8RWJWrs8jUm1dfA+5lS4zgNd078zQAj+yppnyhRGEGuZ6jAVJowtF+gbljZttmZwfXUgV3WpKnT/A==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-2.0.5.tgz",
+      "integrity": "sha512-ZrqRvCCIxGr4qFd/r1pmtd9tobRmv8KAxV7ygFoc/t4vOSKTcVIjhE12gsI3FzgvXM15ZFVwsxa1zodwgo5neQ==",
       "dependencies": {
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -1497,26 +1500,35 @@
       }
     },
     "node_modules/@chakra-ui/alert/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
+      }
+    },
+    "node_modules/@chakra-ui/anatomy": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/anatomy/-/anatomy-1.3.0.tgz",
+      "integrity": "sha512-vj/lcHkCuq/dtbl69DkNsftZTnrGEegB90ODs1B6rxw8iVMdDSYkthPPFAkqzNs4ppv1y2IBjELuVzpeta1OHA==",
+      "dependencies": {
+        "@chakra-ui/theme-tools": "^1.3.6"
       },
       "peerDependencies": {
-        "react": ">=16.8.6"
+        "@chakra-ui/system": ">=1.0.0"
       }
     },
     "node_modules/@chakra-ui/avatar": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/avatar/-/avatar-1.1.3.tgz",
-      "integrity": "sha512-fM5yzEUd7zyFs+bdFnfDEafQoSlt84AdbWoJ9jG55WwFnJ5CWV2kXb0CRe9MADj2V11EKXzQFT/YYeEg00Jb+Q==",
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/avatar/-/avatar-1.3.9.tgz",
+      "integrity": "sha512-QhtVuFRXhV7X5iMCHI1lXOA0U2hJnpKC9uIEB80EkBuNYJDEz/y8ViOQPRivMVU//wymwLcbvjDCZd1urMjVYQ==",
       "dependencies": {
-        "@chakra-ui/image": "1.0.8",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/image": "1.1.8",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -1524,25 +1536,23 @@
       }
     },
     "node_modules/@chakra-ui/avatar/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/breadcrumb": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/breadcrumb/-/breadcrumb-1.1.2.tgz",
-      "integrity": "sha512-spKkKKd8z738ExOGa5zCg8f1YSou8DEYpB5FHbfdQDzyI0VAuwsxZHy4WPPqWf+V7Tgsjnn/gUEYCQIayHcJcw==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/breadcrumb/-/breadcrumb-1.3.6.tgz",
+      "integrity": "sha512-iXxienBO6RUnJEcDvyDWyRt+mzPyl7/b6N8i0vrjGKGLpgtayJFvIdo33tFcvx6TCy7V9hiE3HTtZnNomWdR6A==",
       "dependencies": {
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -1550,26 +1560,25 @@
       }
     },
     "node_modules/@chakra-ui/breadcrumb/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/button": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/button/-/button-1.1.3.tgz",
-      "integrity": "sha512-KfBLKCl7QDwZjVkSo7UEU0zU0u/j8TImU2571L9AVwIrzatQXGuyx4m4PYxrEgU4lb+YhbDwNWNnHgTPNzcdVw==",
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/button/-/button-1.5.8.tgz",
+      "integrity": "sha512-harZywey/6OclxIB5p/Ge/coeGKZWoqmu7JjXlbwTUd3U9IQiOVo/zekY1JscCSz2oZoVBCvoKZVt3on5dPwmA==",
       "dependencies": {
-        "@chakra-ui/spinner": "1.1.2",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/spinner": "1.2.6",
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -1577,80 +1586,74 @@
       }
     },
     "node_modules/@chakra-ui/button/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/checkbox": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/checkbox/-/checkbox-1.2.4.tgz",
-      "integrity": "sha512-4GgkRAPFWHyat6tFfhmdzBeF7W+C0MEsMiSNmF5dsp13/6txsOaUiIg0sy6VzoGAp9rIBEr0IaXjVR3MmSTWsw==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/checkbox/-/checkbox-1.6.8.tgz",
+      "integrity": "sha512-CYmJbMA9BXb6ArKmXIAuQ22aQ97HgtslbJlqRKsV/FmZuk1DXF1dcVXzqeInhe5HacQ8z/+SmSqL9Q3fjswKag==",
       "dependencies": {
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/utils": "1.3.0",
-        "@chakra-ui/visually-hidden": "1.0.5"
+        "@chakra-ui/form-control": "1.5.9",
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/utils": "1.10.4",
+        "@chakra-ui/visually-hidden": "1.1.6"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
-        "framer-motion": ">=3.0.0",
+        "framer-motion": "3.x || 4.x || 5.x || 6.x",
         "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/checkbox/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/clickable": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/clickable/-/clickable-1.0.5.tgz",
-      "integrity": "sha512-bymyXqh3/NTYobgF7ea3o5TaxMo0O7yD97Osj756sLhMl8mbovnKDdPsFO2uL6Y/v+BAvlBUftQVOnwXgMMJkQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/clickable/-/clickable-1.2.6.tgz",
+      "integrity": "sha512-89SsrQwwwAadcl/bN8nZqqaaVhVNFdBXqQnxVy1t07DL5ezubmNb5SgFh9LDznkm9YYPQhaGr3W6HFro7iAHMg==",
       "dependencies": {
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/clickable/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/close-button": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/close-button/-/close-button-1.1.2.tgz",
-      "integrity": "sha512-jLDhVMV5s7BTHDhwZMEPNLlHG8cI5Pw4y0dWrrnGWi3XQIFWYvAfLDhApn7W1cF1ijch000Heloq9WcN/WxilA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/close-button/-/close-button-1.2.7.tgz",
+      "integrity": "sha512-cYTxfgrIlPU4IZm1sehZXxx/TNQBk9c3LBPvTpywEM8GVRGINh4YLq8WiMaPtO+TDNBnKoWS/jS4IHnR+abADw==",
       "dependencies": {
-        "@chakra-ui/icon": "1.1.2",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/icon": "2.0.5",
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -1658,11 +1661,11 @@
       }
     },
     "node_modules/@chakra-ui/close-button/node_modules/@chakra-ui/icon": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-1.1.2.tgz",
-      "integrity": "sha512-Gp/G0CZ8X8RWJWrs8jUm1dfA+5lS4zgNd078zQAj+yppnyhRGEGuZ6jAVJowtF+gbljZttmZwfXUgV3WpKnT/A==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-2.0.5.tgz",
+      "integrity": "sha512-ZrqRvCCIxGr4qFd/r1pmtd9tobRmv8KAxV7ygFoc/t4vOSKTcVIjhE12gsI3FzgvXM15ZFVwsxa1zodwgo5neQ==",
       "dependencies": {
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -1670,51 +1673,46 @@
       }
     },
     "node_modules/@chakra-ui/close-button/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/color-mode": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/color-mode/-/color-mode-1.1.1.tgz",
-      "integrity": "sha512-vTT7SNjYie5O2EucJ+rQvta2srLUHXxY2J0mfOVRIvMzpMr4l49DYAqZmRHFie7rTvV+e0h5JaA3qwdHUsBu/w==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/color-mode/-/color-mode-1.4.6.tgz",
+      "integrity": "sha512-gCO8Z/jv68jXop94MUQNzigl7JXICAgZQUUqLaKhdy1h2zatVDIPFfjwwjnsgM97G0BxQaNBOC87+PD2UYjzHw==",
       "dependencies": {
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/react-env": "1.1.6",
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/color-mode/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/control-box": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/control-box/-/control-box-1.0.5.tgz",
-      "integrity": "sha512-gwmWfobqeNjMlHNG4ATj0yg7p/WYIONwFhLU0l85qLsfSs+GkX5xTBV+ssrnD9l2ADG8lALmDAxgPFOOhLZMvg==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/control-box/-/control-box-1.1.6.tgz",
+      "integrity": "sha512-EUcq5f854puG6ZA6wAWl4107OPl8+bj4MMHJCa48BB0qec0U8HCEtxQGnFwJmaYLalIAjMfHuY3OwO2A3Hi9hA==",
       "dependencies": {
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -1722,72 +1720,67 @@
       }
     },
     "node_modules/@chakra-ui/control-box/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/counter": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/counter/-/counter-1.0.8.tgz",
-      "integrity": "sha512-TynFTt6JmYqg5EreZuv619ePUqXEj6a/zVPGXA3QPgJBEOcNwbhqX/SRaQ1vMD+Cv9xVbxjWFV6J2na5j3E3yQ==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/counter/-/counter-1.2.8.tgz",
+      "integrity": "sha512-lVuK+ycKxEE0G4Jkl8A6GWdXUFAih89KA1IkkhQG6NwqdGzbgouTInwBLg1Sm5uwgQ5QqSr9S42QyDoleUyF0g==",
       "dependencies": {
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/counter/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/css-reset": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/css-reset/-/css-reset-1.0.0.tgz",
-      "integrity": "sha512-UaPsImGHvCgFO3ayp6Ugafu2/3/EG8wlW/8Y9Ihfk1UFv8cpV+3BfWKmuZ7IcmxcBL9dkP6E8p3/M1T0FB92hg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/css-reset/-/css-reset-1.1.3.tgz",
+      "integrity": "sha512-AgfrE7bRTJvNi/4zIfacI/kBHmHmHEIeQtHwCvk/0qM9V2gK1VM3ctYlnibf7BTh17F/UszweOGRb1lHSPfWjw==",
       "peerDependencies": {
         "@emotion/react": ">=10.0.35",
         "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/descendant": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/descendant/-/descendant-1.0.8.tgz",
-      "integrity": "sha512-amKxOoFJ2uiQxJqAw5XZOI5nwVdUQ4BxZAY2Y7kM9Ml5qATxzRiVv8eoyJ0uQ/VksFRfECFxyudFtLm0VwO8hQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/descendant/-/descendant-2.1.3.tgz",
+      "integrity": "sha512-aNYNv99gEPENCdw2N5y3FvL5wgBVcLiOzJ2TxSwb4EVYszbgBZ8Ry1pf7lkoSfysdxD0scgy2cVyxO8TsYTU4g==",
       "dependencies": {
-        "@chakra-ui/hooks": "1.1.5"
+        "@chakra-ui/react-utils": "^1.2.3"
       },
       "peerDependencies": {
         "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/editable": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/editable/-/editable-1.1.2.tgz",
-      "integrity": "sha512-uWt0I8Oo9prs5rDYF2Yqairq2Wl1MMaAU6y2NTSLLq0Un2RTVtyW29TkHFpx7SF1mlrtClyKmh0yk0qEiEMcWQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/editable/-/editable-1.4.0.tgz",
+      "integrity": "sha512-QH5ZMCK/U3pQINtSPiqxxA5XCdiXKBfAI1+siiuSqKtmCriltcArEU4groQn/bm7EY6UJIr/MV3azSDeeBIsaQ==",
       "dependencies": {
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -1795,53 +1788,48 @@
       }
     },
     "node_modules/@chakra-ui/editable/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/focus-lock": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/focus-lock/-/focus-lock-1.1.1.tgz",
-      "integrity": "sha512-fscXuFgaxbf1GnRB3/a7KMwYwcmSGT61XmF5yUOw8PflkBl/4a8u+UuSZMuzw8blD5/fK9thWNJK2Nqq/24aOA==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/focus-lock/-/focus-lock-1.2.6.tgz",
+      "integrity": "sha512-ZJNE1oNdUM1aGWuCJ+bxFa/d3EwxzfMWzTKzSvKDK50GWoUQQ10xFTT9nY/yFpkcwhBvx1KavxKf44mIhIbSog==",
       "dependencies": {
-        "@chakra-ui/utils": "1.3.0",
-        "react-focus-lock": "2.5.0"
+        "@chakra-ui/utils": "1.10.4",
+        "react-focus-lock": "2.5.2"
       },
       "peerDependencies": {
         "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/focus-lock/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/form-control": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/form-control/-/form-control-1.2.2.tgz",
-      "integrity": "sha512-p/tLw25/0NZBeuv6WG9NzRfPkS1EfIcs60IWu7ehxvNrNo4TAzTNkp9eEeSDAgpEin1hlAEBWdi2ZzgvK28qEA==",
+      "version": "1.5.9",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/form-control/-/form-control-1.5.9.tgz",
+      "integrity": "sha512-JuUB9dHXFqTYm+Z+cOULk56AcrX9y3eaied0j/KGdPwtIjS2kkjulq7A8sJJdsle4M6XleMinjW+1KO2PMExQg==",
       "dependencies": {
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/icon": "1.1.2",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/icon": "2.0.5",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -1849,11 +1837,11 @@
       }
     },
     "node_modules/@chakra-ui/form-control/node_modules/@chakra-ui/icon": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-1.1.2.tgz",
-      "integrity": "sha512-Gp/G0CZ8X8RWJWrs8jUm1dfA+5lS4zgNd078zQAj+yppnyhRGEGuZ6jAVJowtF+gbljZttmZwfXUgV3WpKnT/A==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-2.0.5.tgz",
+      "integrity": "sha512-ZrqRvCCIxGr4qFd/r1pmtd9tobRmv8KAxV7ygFoc/t4vOSKTcVIjhE12gsI3FzgvXM15ZFVwsxa1zodwgo5neQ==",
       "dependencies": {
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -1861,25 +1849,23 @@
       }
     },
     "node_modules/@chakra-ui/form-control/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/hooks": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/hooks/-/hooks-1.1.5.tgz",
-      "integrity": "sha512-JBBeQ5woByVRV0yuc318ogyjjIHJJSujdBhOZUmB+nAjlmx5lpFoAm59IAKuH8ZIqZBEzjwcnhKNw67wXjoowQ==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/hooks/-/hooks-1.8.5.tgz",
+      "integrity": "sha512-/UrBfUG7NLxuU/09gy2qQfEH+H5SPBUaUiFtokRlq887D/32JQ3XksZdF78RKMCM/0bbZuIjqUkuN/wO9kAbSw==",
       "dependencies": {
-        "@chakra-ui/utils": "1.3.0",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/utils": "1.10.4",
         "compute-scroll-into-view": "1.0.14",
         "copy-to-clipboard": "3.3.1"
       },
@@ -1888,17 +1874,14 @@
       }
     },
     "node_modules/@chakra-ui/hooks/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/icon": {
@@ -1927,12 +1910,12 @@
       }
     },
     "node_modules/@chakra-ui/image": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/image/-/image-1.0.8.tgz",
-      "integrity": "sha512-WSVFFvx0bJ7qdJslBrj9FGFJvOLXk05rQC+tL+lPI8/jqhzj6EwUzsQ4qXlwcjo8KR5LviMA8zZsaoEZ+kAUqw==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/image/-/image-1.1.8.tgz",
+      "integrity": "sha512-ffO5lyTfGXxaFr9Bdkrb+GahjXsqeph8R1jXYFYwLjos+/sZZJmHJz/cjyoKjKPd6J7puKVZ6Cxz+Ej6PJlQcA==",
       "dependencies": {
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -1940,26 +1923,24 @@
       }
     },
     "node_modules/@chakra-ui/image/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/input": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/input/-/input-1.1.3.tgz",
-      "integrity": "sha512-WwTx6jPTqoXPXMYCftcnIPhJjZqmbcUlju2Oyt32+M1jc1uFa+uUUd2zBfNQVK2KrbzWISquCzYVF5WVehHVtA==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/input/-/input-1.4.4.tgz",
+      "integrity": "sha512-A1TYz8lOdSVuMnWRnR7Y+cddnnr5d2o1Vvd8Im09WW2j09xy06xD/EaFy8dI51Ab0ACldglVs66qx5dO7WoV0w==",
       "dependencies": {
-        "@chakra-ui/form-control": "1.2.2",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/form-control": "1.5.9",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -1967,26 +1948,24 @@
       }
     },
     "node_modules/@chakra-ui/input/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/layout": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/layout/-/layout-1.3.2.tgz",
-      "integrity": "sha512-L2dM3yRu2RKkENpuTiuBxz9Vq07LDhIWLo3aeB7uSbjWNi4kD8pVsHUw4489xEUVnVplC1T4XryM4gDck7jIVg==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/layout/-/layout-1.7.7.tgz",
+      "integrity": "sha512-HuZ/Zv9xWzLip263tX2Vt0oaqwaS6Srw78Sdl3DiGSifN8x+ooEAxmeDAIaU2PO21YX+f6s+9A738NAtSM2R+Q==",
       "dependencies": {
-        "@chakra-ui/icon": "1.1.2",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/icon": "2.0.5",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -1994,11 +1973,11 @@
       }
     },
     "node_modules/@chakra-ui/layout/node_modules/@chakra-ui/icon": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-1.1.2.tgz",
-      "integrity": "sha512-Gp/G0CZ8X8RWJWrs8jUm1dfA+5lS4zgNd078zQAj+yppnyhRGEGuZ6jAVJowtF+gbljZttmZwfXUgV3WpKnT/A==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-2.0.5.tgz",
+      "integrity": "sha512-ZrqRvCCIxGr4qFd/r1pmtd9tobRmv8KAxV7ygFoc/t4vOSKTcVIjhE12gsI3FzgvXM15ZFVwsxa1zodwgo5neQ==",
       "dependencies": {
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2006,50 +1985,45 @@
       }
     },
     "node_modules/@chakra-ui/layout/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/live-region": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/live-region/-/live-region-1.0.5.tgz",
-      "integrity": "sha512-2DBI1wgTcXILW+pEceZwWDK1DbzIS/dNBCZVjkiE2ZT17rxjkl1/olq/em4jaNvlXGcZ9V0EjmiVO3NFM3mFmA==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/live-region/-/live-region-1.1.6.tgz",
+      "integrity": "sha512-9gPQHXf7oW0jXyT5R/JzyDMfJ3hF70TqhN8bRH4fMyfNr2Se+SjztMBqCrv5FS5rPjcCeua+e0eArpoB3ROuWQ==",
       "dependencies": {
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/live-region/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/media-query": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/media-query/-/media-query-1.0.6.tgz",
-      "integrity": "sha512-CRav7owkwkLBJC96vwZjlOpU4igQoZvDFd7aH/u9KivGg3saICtSfHwWPl58WIrowTIkvV5ycHyo0efzcB1S1Q==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/media-query/-/media-query-2.0.4.tgz",
+      "integrity": "sha512-kn6g/L0IFFUHz2v4yiCsBnhg9jUeA7525Z+AWl+BPtvryi7i9J+AJ27y/QAge7vUGy4dwDeFyxOZTs2oZ9/BsA==",
       "dependencies": {
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/react-env": "1.1.6",
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2058,95 +2032,90 @@
       }
     },
     "node_modules/@chakra-ui/media-query/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/menu": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/menu/-/menu-1.1.3.tgz",
-      "integrity": "sha512-tO98inArQCg0nlMgl+9uL9YwN09AClmP3HZtGk/kINTvFD/eqKI/UDh/IcBhlHw5DczPKQtBBWO8yg2z7PqGPg==",
+      "version": "1.8.9",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/menu/-/menu-1.8.9.tgz",
+      "integrity": "sha512-rvQQU56nQoaz+IZXyamKaAU/87IiGIDrX9wEONHth7QDT/93whnFNYPtUMHMzILz0oliysBey4dlmtRzk5vUpQ==",
       "dependencies": {
-        "@chakra-ui/clickable": "1.0.5",
-        "@chakra-ui/descendant": "1.0.8",
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/popper": "1.1.5",
-        "@chakra-ui/transition": "1.0.9",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/clickable": "1.2.6",
+        "@chakra-ui/descendant": "2.1.3",
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/popper": "2.4.3",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/transition": "1.4.7",
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
-        "framer-motion": ">=3.0.0",
+        "framer-motion": "3.x || 4.x || 5.x || 6.x",
         "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/menu/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/modal": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/modal/-/modal-1.6.1.tgz",
-      "integrity": "sha512-Eu2jp2aXrrmaLe+xAqdRQRXdmsMmQMu52gvunYRDoR94oGlKyhixMrxTZrATjq5+JNCV1D1QbwFhh+GvZhjbcg==",
+      "version": "1.10.10",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/modal/-/modal-1.10.10.tgz",
+      "integrity": "sha512-/OLnZhhGXQEaCqtrCCf2nu27mVxT/3Kd+NBNMKGZ4X70Dm6HD3x1Zrsto2hVo8l3kLEPRpkfpXhKu61doMc8zw==",
       "dependencies": {
-        "@chakra-ui/close-button": "1.1.2",
-        "@chakra-ui/focus-lock": "1.1.1",
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/portal": "1.1.2",
-        "@chakra-ui/transition": "1.0.9",
-        "@chakra-ui/utils": "1.3.0",
+        "@chakra-ui/close-button": "1.2.7",
+        "@chakra-ui/focus-lock": "1.2.6",
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/portal": "1.3.8",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/transition": "1.4.7",
+        "@chakra-ui/utils": "1.10.4",
         "aria-hidden": "^1.1.1",
         "react-remove-scroll": "2.4.1"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
-        "framer-motion": ">=3.0.0",
-        "react": ">=16.8.6"
+        "framer-motion": "3.x || 4.x || 5.x || 6.x",
+        "react": ">=16.8.6",
+        "react-dom": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/modal/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/number-input": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/number-input/-/number-input-1.1.2.tgz",
-      "integrity": "sha512-bSiX1cgE7tTJpuaYAqzhheU3F6S+WjlxY7tsJ842KoN8aooMFaB6VClkkjZAQfvCeXLXyYNlDi+FZwlwQq8j3Q==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/number-input/-/number-input-1.4.5.tgz",
+      "integrity": "sha512-jxOvJUEuXZXQrOgMGZ+rPNjSrIoV7MSb7CPt3C1jVuiumr/GgNu54awmrky3Zj4ikj68rREEUXAGKBgm9oU3nQ==",
       "dependencies": {
-        "@chakra-ui/counter": "1.0.8",
-        "@chakra-ui/form-control": "1.2.2",
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/icon": "1.1.2",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/counter": "1.2.8",
+        "@chakra-ui/form-control": "1.5.9",
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/icon": "2.0.5",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2154,11 +2123,11 @@
       }
     },
     "node_modules/@chakra-ui/number-input/node_modules/@chakra-ui/icon": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-1.1.2.tgz",
-      "integrity": "sha512-Gp/G0CZ8X8RWJWrs8jUm1dfA+5lS4zgNd078zQAj+yppnyhRGEGuZ6jAVJowtF+gbljZttmZwfXUgV3WpKnT/A==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-2.0.5.tgz",
+      "integrity": "sha512-ZrqRvCCIxGr4qFd/r1pmtd9tobRmv8KAxV7ygFoc/t4vOSKTcVIjhE12gsI3FzgvXM15ZFVwsxa1zodwgo5neQ==",
       "dependencies": {
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2166,27 +2135,25 @@
       }
     },
     "node_modules/@chakra-ui/number-input/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/pin-input": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/pin-input/-/pin-input-1.4.1.tgz",
-      "integrity": "sha512-0DY+q71VBbjmLh/soUcibj9Mi5+Jr0eKugRP8hzx1ywoSqmNVa4hhw12cC4xeEaO242Ec3752D7TLGCSZFD04Q==",
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/pin-input/-/pin-input-1.7.8.tgz",
+      "integrity": "sha512-P4uJBVKDxTetQhj+s0L7TbUTTqbcHwkLpo4bGUEdQpHMfGFlJgGu0wFT5Z8O0fw+vGNfguFfkqkVRRgK8FkHlA==",
       "dependencies": {
-        "@chakra-ui/descendant": "1.0.8",
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/descendant": "2.1.3",
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2194,86 +2161,64 @@
       }
     },
     "node_modules/@chakra-ui/pin-input/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/popover": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/popover/-/popover-1.2.3.tgz",
-      "integrity": "sha512-hA44W7GwDpQWep5R+4lRkN9C3FE7zW+cTYuJXNNx2CwpUOWCdTAaPwx4LJb+yLmTMbRXDKSR1KrkzWK3C6Abcg==",
+      "version": "1.11.7",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/popover/-/popover-1.11.7.tgz",
+      "integrity": "sha512-TjMZlpBomIuGuQgGQi2rTSVFwFbc9HdJSU3anyFyDQb4ZnunyqaIEMoqFdj/dK8tDdWIatozKjX6AzSimmSvLg==",
       "dependencies": {
-        "@chakra-ui/close-button": "1.1.2",
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/popper": "1.1.5",
-        "@chakra-ui/portal": "1.1.2",
-        "@chakra-ui/transition": "1.0.9",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/close-button": "1.2.7",
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/popper": "2.4.3",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
-        "framer-motion": ">=3.0.0",
+        "framer-motion": "3.x || 4.x || 5.x || 6.x",
         "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/popover/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/popper": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/popper/-/popper-1.1.5.tgz",
-      "integrity": "sha512-Z7NpOMoycnELII8TTEC1FmMqAIO69xJ8pyNL4lo/ifNyTngIuEQw4o40U7rfA4E7A6AM24WmlgwH0lxFOfOqqg==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/popper/-/popper-2.4.3.tgz",
+      "integrity": "sha512-TGzFnYt3mtIVkIejtYIAu4Ka9DaYLzMR4NgcqI6EtaTvgK7Xep+6RTiY/Nq+ZT3l/eaNUwqHRFoNrDUg1XYasA==",
       "dependencies": {
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/utils": "1.3.0",
-        "@popperjs/core": "2.4.4",
-        "dequal": "2.0.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/popper/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
-      "dependencies": {
-        "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
-        "css-box-model": "1.2.1",
-        "lodash.mergewith": "4.6.2"
+        "@chakra-ui/react-utils": "1.2.3",
+        "@popperjs/core": "^2.9.3"
       },
       "peerDependencies": {
         "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/portal": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/portal/-/portal-1.1.2.tgz",
-      "integrity": "sha512-cGZgevVcSC59egLn++nJ2RifrDGzVSZfY8DDpDaoeb7hLqa9w+zWjcMq54+BTHDIJ4PeRjZtnk1gl16KG4V8iQ==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/portal/-/portal-1.3.8.tgz",
+      "integrity": "sha512-rpSu/RdtlKfOBzw11qHs91IwUTffUfppBz33PfOFNZpDGmO0+6pWkz40I16eSgYtQigZRQG1spz6Ul7tsh+1ag==",
       "dependencies": {
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "react": ">=16.8.6",
@@ -2281,26 +2226,23 @@
       }
     },
     "node_modules/@chakra-ui/portal/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/progress": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/progress/-/progress-1.1.2.tgz",
-      "integrity": "sha512-ndxmLq5SF/yaOmDaGPeBuaDelDu3mtf0nzJcCKTVGjLIksTNUt71puQNsTEHGXp089wJlFKJLKAx2i0UqgasWA==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/progress/-/progress-1.2.6.tgz",
+      "integrity": "sha512-thaHRIYTVktgV78vJMNwzfCX+ickhSpn2bun6FtGVUphFx4tjV+ggz+IGohm6AH2hapskoR1mQU2iNZb6BK0hQ==",
       "dependencies": {
-        "@chakra-ui/theme-tools": "1.1.0",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/theme-tools": "1.3.6",
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2308,28 +2250,56 @@
       }
     },
     "node_modules/@chakra-ui/progress/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
+      }
+    },
+    "node_modules/@chakra-ui/provider": {
+      "version": "1.7.12",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/provider/-/provider-1.7.12.tgz",
+      "integrity": "sha512-SSq4z4nMjCbqdGrRkbxzR4o96uRah1HnSFui3lM2263zJN7fyezqiseRboID+i7eIUCBWHMLdsabARAD8t1tDQ==",
+      "dependencies": {
+        "@chakra-ui/css-reset": "1.1.3",
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/portal": "1.3.8",
+        "@chakra-ui/react-env": "1.1.6",
+        "@chakra-ui/system": "1.11.2",
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
-        "react": ">=16.8.6"
+        "@emotion/react": "^11.0.0",
+        "@emotion/styled": "^11.0.0",
+        "react": ">=16.8.6",
+        "react-dom": ">=16.8.6"
+      }
+    },
+    "node_modules/@chakra-ui/provider/node_modules/@chakra-ui/utils": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
+      "dependencies": {
+        "@types/lodash.mergewith": "4.6.6",
+        "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
+        "lodash.mergewith": "4.6.2"
       }
     },
     "node_modules/@chakra-ui/radio": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/radio/-/radio-1.2.4.tgz",
-      "integrity": "sha512-nf9haPcD2jX50XbaiSP5mJUZUUP0wKJSeHeCgMsPtTSMjmQcsr8V8qZ3s31uvy3K17KfPhxChtH7MvDHBNDHsQ==",
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/radio/-/radio-1.4.10.tgz",
+      "integrity": "sha512-TgqBgfezypC4do1Vj4iBp4kptXVWdnhASJ97VFuau2QQPT6zKl3Ke2di+XLhH3CZNCDHpvU/KxQNJ6bfj5GMGg==",
       "dependencies": {
-        "@chakra-ui/form-control": "1.2.2",
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/utils": "1.3.0",
-        "@chakra-ui/visually-hidden": "1.0.5"
+        "@chakra-ui/form-control": "1.5.9",
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/utils": "1.10.4",
+        "@chakra-ui/visually-hidden": "1.1.6"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2337,83 +2307,127 @@
       }
     },
     "node_modules/@chakra-ui/radio/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/react": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-1.3.4.tgz",
-      "integrity": "sha512-RLj+PswKfJ14TTxhmqQeXmCREwoF36QivH0hKt6mu9BeGux5su8hbxcRwfZc+QW7pqyHIy17w0AqVGn79U7uDA==",
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-1.8.6.tgz",
+      "integrity": "sha512-FEh/KG0uPeNOMQuIlyPfGjHvGB7LN1AAhkdFefqzNt0zNy8Giv4p1PKY7wdCh5QEFor++A83L1wIWvTGQVJ2vQ==",
       "dependencies": {
-        "@chakra-ui/accordion": "1.1.3",
-        "@chakra-ui/alert": "1.1.2",
-        "@chakra-ui/avatar": "1.1.3",
-        "@chakra-ui/breadcrumb": "1.1.2",
-        "@chakra-ui/button": "1.1.3",
-        "@chakra-ui/checkbox": "1.2.4",
-        "@chakra-ui/close-button": "1.1.2",
-        "@chakra-ui/control-box": "1.0.5",
-        "@chakra-ui/counter": "1.0.8",
-        "@chakra-ui/css-reset": "1.0.0",
-        "@chakra-ui/editable": "1.1.2",
-        "@chakra-ui/form-control": "1.2.2",
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/icon": "1.1.2",
-        "@chakra-ui/image": "1.0.8",
-        "@chakra-ui/input": "1.1.3",
-        "@chakra-ui/layout": "1.3.2",
-        "@chakra-ui/live-region": "1.0.5",
-        "@chakra-ui/media-query": "1.0.6",
-        "@chakra-ui/menu": "1.1.3",
-        "@chakra-ui/modal": "1.6.1",
-        "@chakra-ui/number-input": "1.1.2",
-        "@chakra-ui/pin-input": "1.4.1",
-        "@chakra-ui/popover": "1.2.3",
-        "@chakra-ui/popper": "1.1.5",
-        "@chakra-ui/portal": "1.1.2",
-        "@chakra-ui/progress": "1.1.2",
-        "@chakra-ui/radio": "1.2.4",
-        "@chakra-ui/select": "1.1.2",
-        "@chakra-ui/skeleton": "1.1.4",
-        "@chakra-ui/slider": "1.1.2",
-        "@chakra-ui/spinner": "1.1.2",
-        "@chakra-ui/stat": "1.1.2",
-        "@chakra-ui/switch": "1.1.4",
-        "@chakra-ui/system": "1.4.0",
-        "@chakra-ui/table": "1.1.2",
-        "@chakra-ui/tabs": "1.2.0",
-        "@chakra-ui/tag": "1.1.2",
-        "@chakra-ui/textarea": "1.1.2",
-        "@chakra-ui/theme": "1.7.0",
-        "@chakra-ui/toast": "1.1.12",
-        "@chakra-ui/tooltip": "1.1.3",
-        "@chakra-ui/transition": "1.0.9",
-        "@chakra-ui/utils": "1.3.0",
-        "@chakra-ui/visually-hidden": "1.0.5"
+        "@chakra-ui/accordion": "1.4.9",
+        "@chakra-ui/alert": "1.3.7",
+        "@chakra-ui/avatar": "1.3.9",
+        "@chakra-ui/breadcrumb": "1.3.6",
+        "@chakra-ui/button": "1.5.8",
+        "@chakra-ui/checkbox": "1.6.8",
+        "@chakra-ui/close-button": "1.2.7",
+        "@chakra-ui/control-box": "1.1.6",
+        "@chakra-ui/counter": "1.2.8",
+        "@chakra-ui/css-reset": "1.1.3",
+        "@chakra-ui/editable": "1.4.0",
+        "@chakra-ui/form-control": "1.5.9",
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/icon": "2.0.5",
+        "@chakra-ui/image": "1.1.8",
+        "@chakra-ui/input": "1.4.4",
+        "@chakra-ui/layout": "1.7.7",
+        "@chakra-ui/live-region": "1.1.6",
+        "@chakra-ui/media-query": "2.0.4",
+        "@chakra-ui/menu": "1.8.9",
+        "@chakra-ui/modal": "1.10.10",
+        "@chakra-ui/number-input": "1.4.5",
+        "@chakra-ui/pin-input": "1.7.8",
+        "@chakra-ui/popover": "1.11.7",
+        "@chakra-ui/popper": "2.4.3",
+        "@chakra-ui/portal": "1.3.8",
+        "@chakra-ui/progress": "1.2.6",
+        "@chakra-ui/provider": "1.7.12",
+        "@chakra-ui/radio": "1.4.10",
+        "@chakra-ui/react-env": "1.1.6",
+        "@chakra-ui/select": "1.2.9",
+        "@chakra-ui/skeleton": "1.2.12",
+        "@chakra-ui/slider": "1.5.9",
+        "@chakra-ui/spinner": "1.2.6",
+        "@chakra-ui/stat": "1.2.7",
+        "@chakra-ui/switch": "1.3.8",
+        "@chakra-ui/system": "1.11.2",
+        "@chakra-ui/table": "1.3.6",
+        "@chakra-ui/tabs": "1.6.8",
+        "@chakra-ui/tag": "1.2.7",
+        "@chakra-ui/textarea": "1.2.9",
+        "@chakra-ui/theme": "1.14.0",
+        "@chakra-ui/toast": "1.5.7",
+        "@chakra-ui/tooltip": "1.4.9",
+        "@chakra-ui/transition": "1.4.7",
+        "@chakra-ui/utils": "1.10.4",
+        "@chakra-ui/visually-hidden": "1.1.6"
       },
       "peerDependencies": {
         "@emotion/react": "^11.0.0",
         "@emotion/styled": "^11.0.0",
-        "framer-motion": ">=3.0.0",
+        "framer-motion": "3.x || 4.x || 5.x || 6.x",
+        "react": ">=16.8.6",
+        "react-dom": ">=16.8.6"
+      }
+    },
+    "node_modules/@chakra-ui/react-env": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-env/-/react-env-1.1.6.tgz",
+      "integrity": "sha512-L90LNvCfe04FTkN9OPok/o2e60zLJNBH8Im/5dUHvqy7dXLXok8ZDad5vEL46XmGbhe7O8fbxhG6FmAYdcCHrQ==",
+      "dependencies": {
+        "@chakra-ui/utils": "1.10.4"
+      },
+      "peerDependencies": {
         "react": ">=16.8.6"
       }
     },
-    "node_modules/@chakra-ui/react/node_modules/@chakra-ui/icon": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-1.1.2.tgz",
-      "integrity": "sha512-Gp/G0CZ8X8RWJWrs8jUm1dfA+5lS4zgNd078zQAj+yppnyhRGEGuZ6jAVJowtF+gbljZttmZwfXUgV3WpKnT/A==",
+    "node_modules/@chakra-ui/react-env/node_modules/@chakra-ui/utils": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
-        "@chakra-ui/utils": "1.3.0"
+        "@types/lodash.mergewith": "4.6.6",
+        "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
+        "lodash.mergewith": "4.6.2"
+      }
+    },
+    "node_modules/@chakra-ui/react-utils": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-utils/-/react-utils-1.2.3.tgz",
+      "integrity": "sha512-r8pUwCVVB7UPhb0AiRa9ZzSp4xkMz64yIeJ4O4aGy4WMw7TRH4j4QkbkE1YC9tQitrXrliOlvx4WWJR4VyiGpw==",
+      "dependencies": {
+        "@chakra-ui/utils": "^1.10.4"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.6"
+      }
+    },
+    "node_modules/@chakra-ui/react-utils/node_modules/@chakra-ui/utils": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
+      "dependencies": {
+        "@types/lodash.mergewith": "4.6.6",
+        "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
+        "lodash.mergewith": "4.6.2"
+      }
+    },
+    "node_modules/@chakra-ui/react/node_modules/@chakra-ui/icon": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-2.0.5.tgz",
+      "integrity": "sha512-ZrqRvCCIxGr4qFd/r1pmtd9tobRmv8KAxV7ygFoc/t4vOSKTcVIjhE12gsI3FzgvXM15ZFVwsxa1zodwgo5neQ==",
+      "dependencies": {
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2421,26 +2435,23 @@
       }
     },
     "node_modules/@chakra-ui/react/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/select": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/select/-/select-1.1.2.tgz",
-      "integrity": "sha512-iN1oarmhBGdLc/MuExyymPsbGBKXTcw/ubkhTgYydGbiyOo8LkYtpzK4tfXyAJEI1banH5kZ7/DxLACqplaamw==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/select/-/select-1.2.9.tgz",
+      "integrity": "sha512-f8cRy3whXFYviuKGfugPnvXTGarPVt2ux5pffipmliYOhfaJ8O2OtdmNJ/od4WaeGStUH13x12GsEqVw2LBKOg==",
       "dependencies": {
-        "@chakra-ui/form-control": "1.2.2",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/form-control": "1.5.9",
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2448,54 +2459,52 @@
       }
     },
     "node_modules/@chakra-ui/select/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/skeleton": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/skeleton/-/skeleton-1.1.4.tgz",
-      "integrity": "sha512-Dp4dmZ1TJRcqoXmRoGQxWI8q2yEPpTCeJquKmmJlca1pHghu9iIfLNdeJ0uZTw5xvm/PO0LIlNc8Kkyw1thMxQ==",
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/skeleton/-/skeleton-1.2.12.tgz",
+      "integrity": "sha512-buHqfKw24+EQXFGHlSRq2obHxZgz0FUKSFNMlQS3tMoFwBkLRO/jAQfjj9KKR5b0m2qu1qLBmwFHJLih1+bnzg==",
       "dependencies": {
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/media-query": "1.0.6",
-        "@chakra-ui/system": "1.4.0",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/media-query": "2.0.4",
+        "@chakra-ui/system": "1.11.2",
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
+        "@chakra-ui/theme": ">=1.0.0",
+        "@emotion/react": "^11.0.0",
+        "@emotion/styled": "^11.0.0",
         "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/skeleton/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/slider": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/slider/-/slider-1.1.2.tgz",
-      "integrity": "sha512-ag5Dr6sXeakcQa+XLtpCM7GVwcZIjhFJt+DkdbxO2dVjUmtJSsAvCBdCUzM63HFzsZTD61RaOXSMWWLcyZ6Rrw==",
+      "version": "1.5.9",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/slider/-/slider-1.5.9.tgz",
+      "integrity": "sha512-m9n/BpnD/hEDS9q3T17ezgTFWDdvCocPzxQXzLLDN2Z2xOgwyLTQVLk4iB1yROvLCUl7Ig9C4+a4/7fivm+IHw==",
       "dependencies": {
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2503,26 +2512,23 @@
       }
     },
     "node_modules/@chakra-ui/slider/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/spinner": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/spinner/-/spinner-1.1.2.tgz",
-      "integrity": "sha512-WZj+XcxXjWPWSjoJoeFupy2RDVqAVqIxFAylFolQ3mhmIAYDSBN6t1lUsSKxl8fWK1lSOAGxTOlvsI6eobMM/w==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/spinner/-/spinner-1.2.6.tgz",
+      "integrity": "sha512-GoUCccN120fGRVgUtfuwcEjeoaxffB+XsgpxX7jhWloXf8b6lkqm68bsxX4Ybb2vGN1fANI98/45JmrnddZO/A==",
       "dependencies": {
-        "@chakra-ui/utils": "1.3.0",
-        "@chakra-ui/visually-hidden": "1.0.5"
+        "@chakra-ui/utils": "1.10.4",
+        "@chakra-ui/visually-hidden": "1.1.6"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2530,27 +2536,24 @@
       }
     },
     "node_modules/@chakra-ui/spinner/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/stat": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/stat/-/stat-1.1.2.tgz",
-      "integrity": "sha512-Iw61iJY8ffx1miB+BOOw6Mnnuic3lD8tepxn8GdUrr+6liBreYbbEe9+VGZeaeU5qx9FDpjr8EtwzzHjKe/X7g==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/stat/-/stat-1.2.7.tgz",
+      "integrity": "sha512-m76jumFW1N+mCG4ytrUz9Mh09nZtS4OQcADEvOslfdI5StwwuzasTA1tueaelPzdhBioMwFUWL05Fr1fXbPJ/Q==",
       "dependencies": {
-        "@chakra-ui/icon": "1.1.2",
-        "@chakra-ui/utils": "1.3.0",
-        "@chakra-ui/visually-hidden": "1.0.5"
+        "@chakra-ui/icon": "2.0.5",
+        "@chakra-ui/utils": "1.10.4",
+        "@chakra-ui/visually-hidden": "1.1.6"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2558,11 +2561,11 @@
       }
     },
     "node_modules/@chakra-ui/stat/node_modules/@chakra-ui/icon": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-1.1.2.tgz",
-      "integrity": "sha512-Gp/G0CZ8X8RWJWrs8jUm1dfA+5lS4zgNd078zQAj+yppnyhRGEGuZ6jAVJowtF+gbljZttmZwfXUgV3WpKnT/A==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-2.0.5.tgz",
+      "integrity": "sha512-ZrqRvCCIxGr4qFd/r1pmtd9tobRmv8KAxV7ygFoc/t4vOSKTcVIjhE12gsI3FzgvXM15ZFVwsxa1zodwgo5neQ==",
       "dependencies": {
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2570,82 +2573,70 @@
       }
     },
     "node_modules/@chakra-ui/stat/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/styled-system": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-1.8.0.tgz",
-      "integrity": "sha512-EKtVaZSW3drOxNBV/Cl3Int3YN9o7BJ9WOsPBcXfdXjAsk5XORN74Mw8HVHPvcheW0ERTlOFWlTSv4Ot/U8GXg==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-1.18.1.tgz",
+      "integrity": "sha512-uhWMNAfkk1DFAQ4nKu+t23WBQ1/XSJq8Y3sBZJQpvopfwOcarbVvEiM5voSUWPA7pkpD/BprGM7zjIRockUcmw==",
       "dependencies": {
-        "@chakra-ui/utils": "1.3.0",
-        "csstype": "^3.0.6"
+        "@chakra-ui/utils": "1.10.4",
+        "csstype": "^3.0.9"
       }
     },
     "node_modules/@chakra-ui/styled-system/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
-    "node_modules/@chakra-ui/styled-system/node_modules/csstype": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.7.tgz",
-      "integrity": "sha512-KxnUB0ZMlnUWCsx2Z8MUsr6qV6ja1w9ArPErJaJaF8a5SOWoHLIszeCTKGRGRgtLgYrs1E8CHkNSP1VZTTPc9g=="
-    },
     "node_modules/@chakra-ui/switch": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/switch/-/switch-1.1.4.tgz",
-      "integrity": "sha512-fqGq7s9Pn4r5o0h9PMM2U60ScJF/6tWefCYqftIiWYNAQek+Iak0sug/JRo2/tbKJq1Vd2kheHVo4eVYRqUVCQ==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/switch/-/switch-1.3.8.tgz",
+      "integrity": "sha512-xcsq4G9YUNRSp0F+XBDjeGZFlJeEdGJptuixk6PZjqRJYUyH+k2bk1bJ2Bv2bjvmkDCojI42MkvWTLHrOqp41A==",
       "dependencies": {
-        "@chakra-ui/checkbox": "1.2.4",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/checkbox": "1.6.8",
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
+        "framer-motion": "3.x || 4.x || 5.x || 6.x",
         "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/switch/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/system": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/system/-/system-1.4.0.tgz",
-      "integrity": "sha512-AvfrF/eVMYJEw5im6sXFcbkxCYQP6RrFcpSjcQ4aD71tfnqDCrlr6oQ8P+fugbrUpGSERoVWpQs1rK4LMTWNLg==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/system/-/system-1.11.2.tgz",
+      "integrity": "sha512-s4HGYVo86XuSav5PLfuVT26Y+l3ca/nQVF6QxS6YCNiUxdBlahlzsZz3yMz3MKp11voljnY8vj4z4dvOd2sjUQ==",
       "dependencies": {
-        "@chakra-ui/color-mode": "1.1.1",
-        "@chakra-ui/styled-system": "1.8.0",
-        "@chakra-ui/utils": "1.3.0",
+        "@chakra-ui/color-mode": "1.4.6",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/styled-system": "1.18.1",
+        "@chakra-ui/utils": "1.10.4",
         "react-fast-compare": "3.2.0"
       },
       "peerDependencies": {
@@ -2655,25 +2646,22 @@
       }
     },
     "node_modules/@chakra-ui/system/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/table": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/table/-/table-1.1.2.tgz",
-      "integrity": "sha512-buaWwNS8VCx3T6izWjmULuIIQKDitI6kObthGIhmG3OsJgkSuzKk5xypK4Oa1b2H03gQT/jGeuwfv8ejjzjITw==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/table/-/table-1.3.6.tgz",
+      "integrity": "sha512-7agZAgAeDFKviqStvixqnLAH54+setzhx67EztioZTr5Xu+6hQ4rotfJbu8L4i587pcbNg98kCEXEkidjw0XRQ==",
       "dependencies": {
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2681,28 +2669,26 @@
       }
     },
     "node_modules/@chakra-ui/table/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/tabs": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/tabs/-/tabs-1.2.0.tgz",
-      "integrity": "sha512-9yorwUbbEqL6b+vDGvbAmOJTucLpC+pHxKCWFHub1DuZNXHKfqVZcBYYKWPVs0ydzVHCwxd0RRmhqtWAP8n0vQ==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/tabs/-/tabs-1.6.8.tgz",
+      "integrity": "sha512-f1kM9VhAXqKzTAVRoPRIINNiUgvBcadP9m5GtjAgE4DzCrQKnTDImjIkFhXlMvWEmB5ynXZcCGlsgIZ2A9Hs9g==",
       "dependencies": {
-        "@chakra-ui/clickable": "1.0.5",
-        "@chakra-ui/descendant": "1.0.8",
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/clickable": "1.2.6",
+        "@chakra-ui/descendant": "2.1.3",
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2710,26 +2696,23 @@
       }
     },
     "node_modules/@chakra-ui/tabs/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/tag": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/tag/-/tag-1.1.2.tgz",
-      "integrity": "sha512-oEGQSll4is63lulTkRwsL4QAOo6iHYaOL0gqSRQmHmHfeDBVNdxvaedN3mnxPPP8oFO8pKGJ9LqcaHe1pj7rTg==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/tag/-/tag-1.2.7.tgz",
+      "integrity": "sha512-RKrKOol4i/CnpFfo3T9LMm1abaqM+5Bs0soQLbo1iJBbBACY09sWXrQYvveQ2GYzU/OrAUloHqqmKjyVGOlNtg==",
       "dependencies": {
-        "@chakra-ui/icon": "1.1.2",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/icon": "2.0.5",
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2737,11 +2720,11 @@
       }
     },
     "node_modules/@chakra-ui/tag/node_modules/@chakra-ui/icon": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-1.1.2.tgz",
-      "integrity": "sha512-Gp/G0CZ8X8RWJWrs8jUm1dfA+5lS4zgNd078zQAj+yppnyhRGEGuZ6jAVJowtF+gbljZttmZwfXUgV3WpKnT/A==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-2.0.5.tgz",
+      "integrity": "sha512-ZrqRvCCIxGr4qFd/r1pmtd9tobRmv8KAxV7ygFoc/t4vOSKTcVIjhE12gsI3FzgvXM15ZFVwsxa1zodwgo5neQ==",
       "dependencies": {
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2749,26 +2732,23 @@
       }
     },
     "node_modules/@chakra-ui/tag/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/textarea": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/textarea/-/textarea-1.1.2.tgz",
-      "integrity": "sha512-yltPY89AbFYKIvyVhj3h2yb5sglkxF6WigNmV/vn3LB2ZTxM0ozTj1rdgPC6LW48UIzRcW9F70L5N77SW0UfAQ==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/textarea/-/textarea-1.2.9.tgz",
+      "integrity": "sha512-HHeUdBA2JrH/S4PopcpOjRmBWKv4wpxQ+Q4mD03UBznyFARZe3XFJOnxhAPdpB/ZadbdgiyXK27TR0uzaqlONw==",
       "dependencies": {
-        "@chakra-ui/form-control": "1.2.2",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/form-control": "1.5.9",
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2776,162 +2756,145 @@
       }
     },
     "node_modules/@chakra-ui/textarea/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/theme": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/theme/-/theme-1.7.0.tgz",
-      "integrity": "sha512-3GqSBOfKrgyq2SZ+Rv6YEFOvhKlyUPh4yCsPq0JpT5fbZjaVPS4zkcoUSqcNzEOyDI4Fb5NYtqhdGWVnLOPDcg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme/-/theme-1.14.0.tgz",
+      "integrity": "sha512-zKy/8JSbiCP0QeBsLzdub7aBnfX2k0qp5vD+RA+mxPEiykEvPGg+TwryxRM5KMZK1Zdgg95aH+9mwiGe9tJt3A==",
       "dependencies": {
-        "@chakra-ui/theme-tools": "1.1.0",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/anatomy": "1.3.0",
+        "@chakra-ui/theme-tools": "1.3.6",
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0"
       }
     },
     "node_modules/@chakra-ui/theme-tools": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-tools/-/theme-tools-1.1.0.tgz",
-      "integrity": "sha512-o1rJBJj3vbhq4C02Ld9Ay1xXKrfphQAqDacowKQlRu8G5DL+EvH/v0RGLkdJQd1ORoUsUZrZBvOcXO9dQt9DeQ==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-tools/-/theme-tools-1.3.6.tgz",
+      "integrity": "sha512-Wxz3XSJhPCU6OwCHEyH44EegEDQHwvlsx+KDkUDGevOjUU88YuNqOVkKtgTpgMLNQcsrYZ93oPWZUJqqCVNRew==",
       "dependencies": {
-        "@chakra-ui/utils": "1.3.0",
-        "@types/tinycolor2": "1.4.2",
-        "tinycolor2": "1.4.2"
+        "@chakra-ui/utils": "1.10.4",
+        "@ctrl/tinycolor": "^3.4.0"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0"
       }
     },
     "node_modules/@chakra-ui/theme-tools/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/theme/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/toast": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/toast/-/toast-1.1.12.tgz",
-      "integrity": "sha512-mLc8mB5mp34UXGD+XKmBYUUiB1dIZtD9AXkLbfeTwMPIsm52vCMk73CnZByr26G8HZM1wXLQF3/UO/1PzeWOug==",
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/toast/-/toast-1.5.7.tgz",
+      "integrity": "sha512-vM88vX2jTfSwOXWqcj9o9pm+msojJS0cG0Pe/wSuYP+D274SdE8oB2OFqJyijsQ7WQq/P6BIlgquzUcS4smu9A==",
       "dependencies": {
-        "@chakra-ui/alert": "1.1.2",
-        "@chakra-ui/close-button": "1.1.2",
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/theme": "1.7.0",
-        "@chakra-ui/transition": "1.0.9",
-        "@chakra-ui/utils": "1.3.0",
-        "@reach/alert": "0.13.0"
+        "@chakra-ui/alert": "1.3.7",
+        "@chakra-ui/close-button": "1.2.7",
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/theme": "1.14.0",
+        "@chakra-ui/transition": "1.4.7",
+        "@chakra-ui/utils": "1.10.4",
+        "@reach/alert": "0.13.2"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
-        "framer-motion": ">=3.0.0",
+        "framer-motion": "3.x || 4.x || 5.x || 6.x",
         "react": ">=16.8.6",
         "react-dom": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/toast/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/tooltip": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/tooltip/-/tooltip-1.1.3.tgz",
-      "integrity": "sha512-wYEezJnMkYT23mwV+NS4cwG5+xOgoPdQ2YBDaOAOHGmX5wX4gZ9YjC9t17MunvFt4hknvjMhtujUSjaYHMSqxA==",
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/tooltip/-/tooltip-1.4.9.tgz",
+      "integrity": "sha512-W1GVMFWkLLBfiFsOddhr7oWr2rTKqSy2xxMkR5MuomNaqORW4tvjN/wNSLMUuUHVxtWM+iRQkslE5r6k5/1HAw==",
       "dependencies": {
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/popper": "1.1.5",
-        "@chakra-ui/portal": "1.1.2",
-        "@chakra-ui/utils": "1.3.0",
-        "@chakra-ui/visually-hidden": "1.0.5"
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/popper": "2.4.3",
+        "@chakra-ui/portal": "1.3.8",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/utils": "1.10.4",
+        "@chakra-ui/visually-hidden": "1.1.6"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
-        "framer-motion": ">=3.0.0",
-        "react": ">=16.8.6"
+        "framer-motion": "3.x || 4.x || 5.x || 6.x",
+        "react": ">=16.8.6",
+        "react-dom": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/tooltip/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/transition": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/transition/-/transition-1.0.9.tgz",
-      "integrity": "sha512-ry7i3VY8xhfWxrOcHs4W7hpyT4HsL3P4qe8jbZICzVxuWL7rtYb26P+yItGJeeujE53m2wKjXqrE8kdSivaMVg==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/transition/-/transition-1.4.7.tgz",
+      "integrity": "sha512-2sbMoKB/enp6Qbte3DD6zwBHyO4YAUSgvSr3wn7DAy4hz9kRZHPuUf/N+i9QZ0whL2koXLgdZvV6RNtSTShq4g==",
       "dependencies": {
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
-        "framer-motion": ">=3.0.0",
+        "framer-motion": "3.x || 4.x || 5.x || 6.x",
         "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/transition/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/utils": {
@@ -2950,11 +2913,11 @@
       }
     },
     "node_modules/@chakra-ui/visually-hidden": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/visually-hidden/-/visually-hidden-1.0.5.tgz",
-      "integrity": "sha512-EIRZ081CgfFqhnOuhTfoluoqaKtx1id3/oCLk9QrJcB3s3r3PWexg41/z0WUaQzeQSPobw3hz5M5QxymmrZ4UQ==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/visually-hidden/-/visually-hidden-1.1.6.tgz",
+      "integrity": "sha512-Xzy5bA0UA+IyMgwJizQYSEdgz8cC/tHdmFB3CniXzmpKTSK8mJddeEBl+cGbXHBzxEUhH7xF1eaS41O+0ezWEQ==",
       "dependencies": {
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
@@ -2962,17 +2925,14 @@
       }
     },
     "node_modules/@chakra-ui/visually-hidden/node_modules/@chakra-ui/utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-      "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.6",
-        "@types/object-assign": "4.0.30",
         "css-box-model": "1.2.1",
+        "framesync": "5.3.0",
         "lodash.mergewith": "4.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@cnakazawa/watch": {
@@ -3002,6 +2962,14 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-10.1.0.tgz",
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
+    },
+    "node_modules/@ctrl/tinycolor": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.4.0.tgz",
+      "integrity": "sha512-JZButFdZ1+/xAfpguQHoabIXkcqRRKpMrWKBkpEZZyxfY9C1DpADFB8PEqGSTeFr135SaTRfKqGKx5xSCLI7ZQ==",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.1.2",
@@ -3454,23 +3422,23 @@
       }
     },
     "node_modules/@popperjs/core": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.4.4.tgz",
-      "integrity": "sha512-1oO6+dN5kdIA3sKPZhRGJTfGVP4SWV6KqlMOwry4J3HfyD68sl/3KmG7DeYUzvN+RbhXDnv/D8vNNB8168tAMg==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.2.tgz",
+      "integrity": "sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@reach/alert": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@reach/alert/-/alert-0.13.0.tgz",
-      "integrity": "sha512-5lpgRnlQ0JHBsRTPfKjD9aFPDZuLcaxTgD5PXdSLb+1CU8WgNbcy+7qSjqnu1uzWS2pQenIEBViV5wGpt63ADw==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@reach/alert/-/alert-0.13.2.tgz",
+      "integrity": "sha512-LDz83AXCrClyq/MWe+0vaZfHp1Ytqn+kgL5VxG7rirUvmluWaj/snxzfNPWn0Ma4K2YENmXXRC/iHt5X95SqIg==",
       "dependencies": {
-        "@reach/utils": "0.13.0",
-        "@reach/visually-hidden": "0.13.0",
+        "@reach/utils": "0.13.2",
+        "@reach/visually-hidden": "0.13.2",
         "prop-types": "^15.7.2",
-        "tslib": "^2.0.0"
+        "tslib": "^2.1.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || 17.x",
@@ -3478,17 +3446,17 @@
       }
     },
     "node_modules/@reach/alert/node_modules/tslib": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@reach/utils": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.13.0.tgz",
-      "integrity": "sha512-dypxuyA1Qy3LHxzzyS7jFGPgCCR04b8UEn+Tv/aj6y9V578dULQqkcCyobrdEa+OI8lxH7dFFHa+jH8M/noBrQ==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.13.2.tgz",
+      "integrity": "sha512-3ir6cN60zvUrwjOJu7C6jec/samqAeyAB12ZADK+qjnmQPdzSYldrFWwDVV5H0WkhbYXR3uh+eImu13hCetNPQ==",
       "dependencies": {
         "@types/warning": "^3.0.0",
-        "tslib": "^2.0.0",
+        "tslib": "^2.1.0",
         "warning": "^4.0.3"
       },
       "peerDependencies": {
@@ -3497,16 +3465,17 @@
       }
     },
     "node_modules/@reach/utils/node_modules/tslib": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@reach/visually-hidden": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@reach/visually-hidden/-/visually-hidden-0.13.0.tgz",
-      "integrity": "sha512-LF11WL9/495Q3d86xNy0VO6ylPI6SqF2xZGg9jpZSXLbFKpQ5Bf0qC7DOJfSf+/yb9WgPgB4m+a48Fz8AO6oZA==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@reach/visually-hidden/-/visually-hidden-0.13.2.tgz",
+      "integrity": "sha512-sPZwNS0/duOuG0mYwE5DmgEAzW9VhgU3aIt1+mrfT/xiT9Cdncqke+kRBQgU708q/Ttm9tWsoHni03nn/SuPTQ==",
       "dependencies": {
-        "tslib": "^2.0.0"
+        "prop-types": "^15.7.2",
+        "tslib": "^2.1.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || 17.x",
@@ -3514,9 +3483,9 @@
       }
     },
     "node_modules/@reach/visually-hidden/node_modules/tslib": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "4.2.0",
@@ -3900,11 +3869,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw=="
-    },
-    "node_modules/@types/tinycolor2": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@types/tinycolor2/-/tinycolor2-1.4.2.tgz",
-      "integrity": "sha512-PeHg/AtdW6aaIO2a+98Xj7rWY4KC1E6yOy7AFknJQ7VXUGNrMlyxDFxJo7HqLtjQms/ZhhQX52mLVW/EX3JGOw=="
     },
     "node_modules/@types/warning": {
       "version": "3.0.0",
@@ -4461,9 +4425,9 @@
       }
     },
     "node_modules/aria-hidden": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.1.2.tgz",
-      "integrity": "sha512-WAMH9q3vRimVqP+B0q2eDvx7IPDoY17A2fWwj5atTA/zTYJCNcS6HJ5YErZ5FO3PUHhrV0y0yR1NA0dRNm913A==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.1.3.tgz",
+      "integrity": "sha512-RhVWFtKH5BiGMycI72q2RAFMLQi8JP9bLuQXgR5a8Znp7P5KOIADSJeyfI8PCVxLEp067B2HbP5JIiI/PXIZeA==",
       "dependencies": {
         "tslib": "^1.0.0"
       },
@@ -6829,9 +6793,9 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
-      "integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag=="
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz",
+      "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw=="
     },
     "node_modules/cyclist": {
       "version": "1.0.1",
@@ -7079,14 +7043,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/dequal": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
-      "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/des.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
@@ -7115,9 +7071,9 @@
       "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
     },
     "node_modules/detect-node-es": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.0.0.tgz",
-      "integrity": "sha512-S4AHriUkTX9FoFvL4G8hXDcx6t3gp2HpfCza3Q0v6S78gul2hKWifLQbeW+ZF89+hSm2ZIc/uF3J97ZgytgTRg=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
     "node_modules/detect-port-alt": {
       "version": "1.1.6",
@@ -8860,15 +8816,20 @@
       }
     },
     "node_modules/focus-lock": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.8.1.tgz",
-      "integrity": "sha512-/LFZOIo82WDsyyv7h7oc0MJF9ACOvDRdx9rWPZ2pgMfNWu/z8hQDBtOchuB/0BVLmuFOZjV02YwUVzNsWx/EzA==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.9.2.tgz",
+      "integrity": "sha512-YtHxjX7a0IC0ZACL5wsX8QdncXofWpGPNoVMuI/nZUrPGp6LmNI6+D5j0pPj+v8Kw5EpweA+T5yImK0rnWf7oQ==",
       "dependencies": {
-        "tslib": "^1.9.3"
+        "tslib": "^2.0.3"
       },
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/focus-lock/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/follow-redirects": {
       "version": "1.13.0",
@@ -8971,31 +8932,41 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "2.9.5",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-2.9.5.tgz",
-      "integrity": "sha512-epSX4Co1YbDv0mjfHouuY0q361TpHE7WQzCp/xMTilxy4kXd+Z23uJzPVorfzbm1a/9q1Yu8T5bndaw65NI4Tg==",
+      "version": "4.1.17",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-4.1.17.tgz",
+      "integrity": "sha512-thx1wvKzblzbs0XaK2X0G1JuwIdARcoNOW7VVwjO8BUltzXPyONGAElLu6CiCScsOQRI7FIk/45YTFtJw5Yozw==",
       "dependencies": {
-        "framesync": "^4.1.0",
+        "framesync": "5.3.0",
         "hey-listen": "^1.0.8",
-        "popmotion": "9.0.0-rc.20",
-        "style-value-types": "^3.1.9",
-        "tslib": "^1.10.0"
+        "popmotion": "9.3.6",
+        "style-value-types": "4.1.4",
+        "tslib": "^2.1.0"
       },
       "optionalDependencies": {
         "@emotion/is-prop-valid": "^0.8.2"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": ">=16.8 || ^17.0.0",
+        "react-dom": ">=16.8 || ^17.0.0"
       }
     },
+    "node_modules/framer-motion/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
     "node_modules/framesync": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/framesync/-/framesync-4.1.0.tgz",
-      "integrity": "sha512-MmgZ4wCoeVxNbx2xp5hN/zPDCbLSKiDt4BbbslK7j/pM2lg5S0vhTNv1v8BCVb99JPIo6hXBFdwzU7Q4qcAaoQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/framesync/-/framesync-5.3.0.tgz",
+      "integrity": "sha512-oc5m68HDO/tuK2blj7ZcdEBRx3p1PjrgHazL8GYEpvULhrtGIFbQArN6cQS2QhW8mitffaB+VYzMjDqBxxQeoA==",
       "dependencies": {
-        "hey-listen": "^1.0.5"
+        "tslib": "^2.1.0"
       }
+    },
+    "node_modules/framesync/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/fresh": {
       "version": "0.5.2",
@@ -13036,15 +13007,20 @@
       }
     },
     "node_modules/popmotion": {
-      "version": "9.0.0-rc.20",
-      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-9.0.0-rc.20.tgz",
-      "integrity": "sha512-f98sny03WuA+c8ckBjNNXotJD4G2utG/I3Q23NU69OEafrXtxxSukAaJBxzbtxwDvz3vtZK69pu9ojdkMoBNTg==",
+      "version": "9.3.6",
+      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-9.3.6.tgz",
+      "integrity": "sha512-ZTbXiu6zIggXzIliMi8LGxXBF5ST+wkpXGEjeTUDUOCdSQ356hij/xjeUdv0F8zCQNeqB1+PR5/BB+gC+QLAPw==",
       "dependencies": {
-        "framesync": "^4.1.0",
+        "framesync": "5.3.0",
         "hey-listen": "^1.0.8",
-        "style-value-types": "^3.1.9",
-        "tslib": "^1.10.0"
+        "style-value-types": "4.1.4",
+        "tslib": "^2.1.0"
       }
+    },
+    "node_modules/popmotion/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/portfinder": {
       "version": "1.0.28",
@@ -14567,14 +14543,6 @@
         "react": "^15.3.0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/react-clientside-effect/node_modules/@babel/runtime": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
-      "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
-      "dependencies": {
-        "regenerator-runtime": "^0.13.4"
-      }
-    },
     "node_modules/react-dev-utils": {
       "version": "10.2.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-10.2.1.tgz",
@@ -14862,16 +14830,16 @@
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
     "node_modules/react-focus-lock": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.5.0.tgz",
-      "integrity": "sha512-XLxj6uTXgz0US8TmqNU2jMfnXwZG0mH2r/afQqvPEaX6nyEll5LHVcEXk2XDUQ34RVeLPkO/xK5x6c/qiuSq/A==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.5.2.tgz",
+      "integrity": "sha512-WzpdOnEqjf+/A3EH9opMZWauag7gV0BxFl+EY4ElA4qFqYsUsBLnmo2sELbN5OC30S16GAWMy16B9DLPpdJKAQ==",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
-        "focus-lock": "^0.8.1",
+        "focus-lock": "^0.9.1",
         "prop-types": "^15.6.2",
-        "react-clientside-effect": "^1.2.2",
-        "use-callback-ref": "^1.2.1",
-        "use-sidecar": "^1.0.1"
+        "react-clientside-effect": "^1.2.5",
+        "use-callback-ref": "^1.2.5",
+        "use-sidecar": "^1.0.5"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0"
@@ -16906,13 +16874,18 @@
       }
     },
     "node_modules/style-value-types": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-3.1.9.tgz",
-      "integrity": "sha512-050uqgB7WdvtgacoQKm+4EgKzJExVq0sieKBQQtJiU3Muh6MYcCp4T3M8+dfl6VOF2LR0NNwXBP1QYEed8DfIw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-4.1.4.tgz",
+      "integrity": "sha512-LCJL6tB+vPSUoxgUBt9juXIlNJHtBMy8jkXzUJSBzeHWdBu6lhzHqCvLVkXFGsFIlNa2ln1sQHya/gzaFmB2Lg==",
       "dependencies": {
         "hey-listen": "^1.0.8",
-        "tslib": "^1.10.0"
+        "tslib": "^2.1.0"
       }
+    },
+    "node_modules/style-value-types/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/stylehacks": {
       "version": "4.0.3",
@@ -17298,14 +17271,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
       "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
-    },
-    "node_modules/tinycolor2": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
-      "integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA==",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/tmp": {
       "version": "0.0.33",
@@ -17748,11 +17713,11 @@
       }
     },
     "node_modules/use-sidecar": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.0.4.tgz",
-      "integrity": "sha512-A5ggIS3/qTdxCAlcy05anO2/oqXOfpmxnpRE1Jm+fHHtCvUvNSZDGqgOSAXPriBVAcw2fMFFkh5v5KqrFFhCMA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.0.5.tgz",
+      "integrity": "sha512-k9jnrjYNwN6xYLj1iaGhonDghfvmeTmYjAiGvOr7clwKfPjMXJf4/HOr7oT5tJwYafgp2tG2l3eZEOfoELiMcA==",
       "dependencies": {
-        "detect-node-es": "^1.0.0",
+        "detect-node-es": "^1.1.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -20074,9 +20039,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.11.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-      "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+      "version": "7.17.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
+      "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -20127,379 +20092,400 @@
       }
     },
     "@chakra-ui/accordion": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/accordion/-/accordion-1.1.3.tgz",
-      "integrity": "sha512-if61BesRBHK5kmqfS0FesTtsmoYcpSYdgcn2cQ0nk9vEc2RvK6H8FTPlFvu64ycpbD73sa9unpdNdxTtzZp7bw==",
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/accordion/-/accordion-1.4.9.tgz",
+      "integrity": "sha512-ZrfrLwAu6p9B41sZ+iEWjfPW/mn2TdUDXv165qr1O355619e2Btjb01x3IYoN4GlE2iF7GOVjC5uYGNyLpBlZg==",
       "requires": {
-        "@chakra-ui/descendant": "1.0.8",
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/icon": "1.1.2",
-        "@chakra-ui/transition": "1.0.9",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/descendant": "2.1.3",
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/icon": "2.0.5",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/transition": "1.4.7",
+        "@chakra-ui/utils": "1.10.4"
       },
       "dependencies": {
         "@chakra-ui/icon": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-1.1.2.tgz",
-          "integrity": "sha512-Gp/G0CZ8X8RWJWrs8jUm1dfA+5lS4zgNd078zQAj+yppnyhRGEGuZ6jAVJowtF+gbljZttmZwfXUgV3WpKnT/A==",
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-2.0.5.tgz",
+          "integrity": "sha512-ZrqRvCCIxGr4qFd/r1pmtd9tobRmv8KAxV7ygFoc/t4vOSKTcVIjhE12gsI3FzgvXM15ZFVwsxa1zodwgo5neQ==",
           "requires": {
-            "@chakra-ui/utils": "1.3.0"
+            "@chakra-ui/utils": "1.10.4"
           }
         },
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/alert": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/alert/-/alert-1.1.2.tgz",
-      "integrity": "sha512-paJyY9S7EvYPZVqpvP3EyzzqXRRQDsEbR62ohfpFQg6C5+S5YWgjos/0YJNPEHDDj/XSQ/4RuAis78CcfivzwQ==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/alert/-/alert-1.3.7.tgz",
+      "integrity": "sha512-fFpJYBpHOIK/BX4BVl/xafYiDBUW+Bq/gUYDOo4iAiO4vHgxo74oa+yOwSRNlNjAgIX7pi2ridsYQALKyWyxxQ==",
       "requires": {
-        "@chakra-ui/icon": "1.1.2",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/icon": "2.0.5",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/utils": "1.10.4"
       },
       "dependencies": {
         "@chakra-ui/icon": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-1.1.2.tgz",
-          "integrity": "sha512-Gp/G0CZ8X8RWJWrs8jUm1dfA+5lS4zgNd078zQAj+yppnyhRGEGuZ6jAVJowtF+gbljZttmZwfXUgV3WpKnT/A==",
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-2.0.5.tgz",
+          "integrity": "sha512-ZrqRvCCIxGr4qFd/r1pmtd9tobRmv8KAxV7ygFoc/t4vOSKTcVIjhE12gsI3FzgvXM15ZFVwsxa1zodwgo5neQ==",
           "requires": {
-            "@chakra-ui/utils": "1.3.0"
+            "@chakra-ui/utils": "1.10.4"
           }
         },
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
-    "@chakra-ui/avatar": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/avatar/-/avatar-1.1.3.tgz",
-      "integrity": "sha512-fM5yzEUd7zyFs+bdFnfDEafQoSlt84AdbWoJ9jG55WwFnJ5CWV2kXb0CRe9MADj2V11EKXzQFT/YYeEg00Jb+Q==",
+    "@chakra-ui/anatomy": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/anatomy/-/anatomy-1.3.0.tgz",
+      "integrity": "sha512-vj/lcHkCuq/dtbl69DkNsftZTnrGEegB90ODs1B6rxw8iVMdDSYkthPPFAkqzNs4ppv1y2IBjELuVzpeta1OHA==",
       "requires": {
-        "@chakra-ui/image": "1.0.8",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/theme-tools": "^1.3.6"
+      }
+    },
+    "@chakra-ui/avatar": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/avatar/-/avatar-1.3.9.tgz",
+      "integrity": "sha512-QhtVuFRXhV7X5iMCHI1lXOA0U2hJnpKC9uIEB80EkBuNYJDEz/y8ViOQPRivMVU//wymwLcbvjDCZd1urMjVYQ==",
+      "requires": {
+        "@chakra-ui/image": "1.1.8",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/utils": "1.10.4"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/breadcrumb": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/breadcrumb/-/breadcrumb-1.1.2.tgz",
-      "integrity": "sha512-spKkKKd8z738ExOGa5zCg8f1YSou8DEYpB5FHbfdQDzyI0VAuwsxZHy4WPPqWf+V7Tgsjnn/gUEYCQIayHcJcw==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/breadcrumb/-/breadcrumb-1.3.6.tgz",
+      "integrity": "sha512-iXxienBO6RUnJEcDvyDWyRt+mzPyl7/b6N8i0vrjGKGLpgtayJFvIdo33tFcvx6TCy7V9hiE3HTtZnNomWdR6A==",
       "requires": {
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/utils": "1.10.4"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/button": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/button/-/button-1.1.3.tgz",
-      "integrity": "sha512-KfBLKCl7QDwZjVkSo7UEU0zU0u/j8TImU2571L9AVwIrzatQXGuyx4m4PYxrEgU4lb+YhbDwNWNnHgTPNzcdVw==",
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/button/-/button-1.5.8.tgz",
+      "integrity": "sha512-harZywey/6OclxIB5p/Ge/coeGKZWoqmu7JjXlbwTUd3U9IQiOVo/zekY1JscCSz2oZoVBCvoKZVt3on5dPwmA==",
       "requires": {
-        "@chakra-ui/spinner": "1.1.2",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/spinner": "1.2.6",
+        "@chakra-ui/utils": "1.10.4"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/checkbox": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/checkbox/-/checkbox-1.2.4.tgz",
-      "integrity": "sha512-4GgkRAPFWHyat6tFfhmdzBeF7W+C0MEsMiSNmF5dsp13/6txsOaUiIg0sy6VzoGAp9rIBEr0IaXjVR3MmSTWsw==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/checkbox/-/checkbox-1.6.8.tgz",
+      "integrity": "sha512-CYmJbMA9BXb6ArKmXIAuQ22aQ97HgtslbJlqRKsV/FmZuk1DXF1dcVXzqeInhe5HacQ8z/+SmSqL9Q3fjswKag==",
       "requires": {
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/utils": "1.3.0",
-        "@chakra-ui/visually-hidden": "1.0.5"
+        "@chakra-ui/form-control": "1.5.9",
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/utils": "1.10.4",
+        "@chakra-ui/visually-hidden": "1.1.6"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/clickable": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/clickable/-/clickable-1.0.5.tgz",
-      "integrity": "sha512-bymyXqh3/NTYobgF7ea3o5TaxMo0O7yD97Osj756sLhMl8mbovnKDdPsFO2uL6Y/v+BAvlBUftQVOnwXgMMJkQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/clickable/-/clickable-1.2.6.tgz",
+      "integrity": "sha512-89SsrQwwwAadcl/bN8nZqqaaVhVNFdBXqQnxVy1t07DL5ezubmNb5SgFh9LDznkm9YYPQhaGr3W6HFro7iAHMg==",
       "requires": {
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/utils": "1.10.4"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/close-button": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/close-button/-/close-button-1.1.2.tgz",
-      "integrity": "sha512-jLDhVMV5s7BTHDhwZMEPNLlHG8cI5Pw4y0dWrrnGWi3XQIFWYvAfLDhApn7W1cF1ijch000Heloq9WcN/WxilA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/close-button/-/close-button-1.2.7.tgz",
+      "integrity": "sha512-cYTxfgrIlPU4IZm1sehZXxx/TNQBk9c3LBPvTpywEM8GVRGINh4YLq8WiMaPtO+TDNBnKoWS/jS4IHnR+abADw==",
       "requires": {
-        "@chakra-ui/icon": "1.1.2",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/icon": "2.0.5",
+        "@chakra-ui/utils": "1.10.4"
       },
       "dependencies": {
         "@chakra-ui/icon": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-1.1.2.tgz",
-          "integrity": "sha512-Gp/G0CZ8X8RWJWrs8jUm1dfA+5lS4zgNd078zQAj+yppnyhRGEGuZ6jAVJowtF+gbljZttmZwfXUgV3WpKnT/A==",
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-2.0.5.tgz",
+          "integrity": "sha512-ZrqRvCCIxGr4qFd/r1pmtd9tobRmv8KAxV7ygFoc/t4vOSKTcVIjhE12gsI3FzgvXM15ZFVwsxa1zodwgo5neQ==",
           "requires": {
-            "@chakra-ui/utils": "1.3.0"
+            "@chakra-ui/utils": "1.10.4"
           }
         },
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/color-mode": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/color-mode/-/color-mode-1.1.1.tgz",
-      "integrity": "sha512-vTT7SNjYie5O2EucJ+rQvta2srLUHXxY2J0mfOVRIvMzpMr4l49DYAqZmRHFie7rTvV+e0h5JaA3qwdHUsBu/w==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/color-mode/-/color-mode-1.4.6.tgz",
+      "integrity": "sha512-gCO8Z/jv68jXop94MUQNzigl7JXICAgZQUUqLaKhdy1h2zatVDIPFfjwwjnsgM97G0BxQaNBOC87+PD2UYjzHw==",
       "requires": {
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/react-env": "1.1.6",
+        "@chakra-ui/utils": "1.10.4"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/control-box": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/control-box/-/control-box-1.0.5.tgz",
-      "integrity": "sha512-gwmWfobqeNjMlHNG4ATj0yg7p/WYIONwFhLU0l85qLsfSs+GkX5xTBV+ssrnD9l2ADG8lALmDAxgPFOOhLZMvg==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/control-box/-/control-box-1.1.6.tgz",
+      "integrity": "sha512-EUcq5f854puG6ZA6wAWl4107OPl8+bj4MMHJCa48BB0qec0U8HCEtxQGnFwJmaYLalIAjMfHuY3OwO2A3Hi9hA==",
       "requires": {
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/utils": "1.10.4"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/counter": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/counter/-/counter-1.0.8.tgz",
-      "integrity": "sha512-TynFTt6JmYqg5EreZuv619ePUqXEj6a/zVPGXA3QPgJBEOcNwbhqX/SRaQ1vMD+Cv9xVbxjWFV6J2na5j3E3yQ==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/counter/-/counter-1.2.8.tgz",
+      "integrity": "sha512-lVuK+ycKxEE0G4Jkl8A6GWdXUFAih89KA1IkkhQG6NwqdGzbgouTInwBLg1Sm5uwgQ5QqSr9S42QyDoleUyF0g==",
       "requires": {
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/utils": "1.10.4"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/css-reset": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/css-reset/-/css-reset-1.0.0.tgz",
-      "integrity": "sha512-UaPsImGHvCgFO3ayp6Ugafu2/3/EG8wlW/8Y9Ihfk1UFv8cpV+3BfWKmuZ7IcmxcBL9dkP6E8p3/M1T0FB92hg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/css-reset/-/css-reset-1.1.3.tgz",
+      "integrity": "sha512-AgfrE7bRTJvNi/4zIfacI/kBHmHmHEIeQtHwCvk/0qM9V2gK1VM3ctYlnibf7BTh17F/UszweOGRb1lHSPfWjw==",
       "requires": {}
     },
     "@chakra-ui/descendant": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/descendant/-/descendant-1.0.8.tgz",
-      "integrity": "sha512-amKxOoFJ2uiQxJqAw5XZOI5nwVdUQ4BxZAY2Y7kM9Ml5qATxzRiVv8eoyJ0uQ/VksFRfECFxyudFtLm0VwO8hQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/descendant/-/descendant-2.1.3.tgz",
+      "integrity": "sha512-aNYNv99gEPENCdw2N5y3FvL5wgBVcLiOzJ2TxSwb4EVYszbgBZ8Ry1pf7lkoSfysdxD0scgy2cVyxO8TsYTU4g==",
       "requires": {
-        "@chakra-ui/hooks": "1.1.5"
+        "@chakra-ui/react-utils": "^1.2.3"
       }
     },
     "@chakra-ui/editable": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/editable/-/editable-1.1.2.tgz",
-      "integrity": "sha512-uWt0I8Oo9prs5rDYF2Yqairq2Wl1MMaAU6y2NTSLLq0Un2RTVtyW29TkHFpx7SF1mlrtClyKmh0yk0qEiEMcWQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/editable/-/editable-1.4.0.tgz",
+      "integrity": "sha512-QH5ZMCK/U3pQINtSPiqxxA5XCdiXKBfAI1+siiuSqKtmCriltcArEU4groQn/bm7EY6UJIr/MV3azSDeeBIsaQ==",
       "requires": {
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/utils": "1.10.4"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/focus-lock": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/focus-lock/-/focus-lock-1.1.1.tgz",
-      "integrity": "sha512-fscXuFgaxbf1GnRB3/a7KMwYwcmSGT61XmF5yUOw8PflkBl/4a8u+UuSZMuzw8blD5/fK9thWNJK2Nqq/24aOA==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/focus-lock/-/focus-lock-1.2.6.tgz",
+      "integrity": "sha512-ZJNE1oNdUM1aGWuCJ+bxFa/d3EwxzfMWzTKzSvKDK50GWoUQQ10xFTT9nY/yFpkcwhBvx1KavxKf44mIhIbSog==",
       "requires": {
-        "@chakra-ui/utils": "1.3.0",
-        "react-focus-lock": "2.5.0"
+        "@chakra-ui/utils": "1.10.4",
+        "react-focus-lock": "2.5.2"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/form-control": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/form-control/-/form-control-1.2.2.tgz",
-      "integrity": "sha512-p/tLw25/0NZBeuv6WG9NzRfPkS1EfIcs60IWu7ehxvNrNo4TAzTNkp9eEeSDAgpEin1hlAEBWdi2ZzgvK28qEA==",
+      "version": "1.5.9",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/form-control/-/form-control-1.5.9.tgz",
+      "integrity": "sha512-JuUB9dHXFqTYm+Z+cOULk56AcrX9y3eaied0j/KGdPwtIjS2kkjulq7A8sJJdsle4M6XleMinjW+1KO2PMExQg==",
       "requires": {
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/icon": "1.1.2",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/icon": "2.0.5",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/utils": "1.10.4"
       },
       "dependencies": {
         "@chakra-ui/icon": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-1.1.2.tgz",
-          "integrity": "sha512-Gp/G0CZ8X8RWJWrs8jUm1dfA+5lS4zgNd078zQAj+yppnyhRGEGuZ6jAVJowtF+gbljZttmZwfXUgV3WpKnT/A==",
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-2.0.5.tgz",
+          "integrity": "sha512-ZrqRvCCIxGr4qFd/r1pmtd9tobRmv8KAxV7ygFoc/t4vOSKTcVIjhE12gsI3FzgvXM15ZFVwsxa1zodwgo5neQ==",
           "requires": {
-            "@chakra-ui/utils": "1.3.0"
+            "@chakra-ui/utils": "1.10.4"
           }
         },
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/hooks": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/hooks/-/hooks-1.1.5.tgz",
-      "integrity": "sha512-JBBeQ5woByVRV0yuc318ogyjjIHJJSujdBhOZUmB+nAjlmx5lpFoAm59IAKuH8ZIqZBEzjwcnhKNw67wXjoowQ==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/hooks/-/hooks-1.8.5.tgz",
+      "integrity": "sha512-/UrBfUG7NLxuU/09gy2qQfEH+H5SPBUaUiFtokRlq887D/32JQ3XksZdF78RKMCM/0bbZuIjqUkuN/wO9kAbSw==",
       "requires": {
-        "@chakra-ui/utils": "1.3.0",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/utils": "1.10.4",
         "compute-scroll-into-view": "1.0.14",
         "copy-to-clipboard": "3.3.1"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
@@ -20523,827 +20509,888 @@
       }
     },
     "@chakra-ui/image": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/image/-/image-1.0.8.tgz",
-      "integrity": "sha512-WSVFFvx0bJ7qdJslBrj9FGFJvOLXk05rQC+tL+lPI8/jqhzj6EwUzsQ4qXlwcjo8KR5LviMA8zZsaoEZ+kAUqw==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/image/-/image-1.1.8.tgz",
+      "integrity": "sha512-ffO5lyTfGXxaFr9Bdkrb+GahjXsqeph8R1jXYFYwLjos+/sZZJmHJz/cjyoKjKPd6J7puKVZ6Cxz+Ej6PJlQcA==",
       "requires": {
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/utils": "1.10.4"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/input": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/input/-/input-1.1.3.tgz",
-      "integrity": "sha512-WwTx6jPTqoXPXMYCftcnIPhJjZqmbcUlju2Oyt32+M1jc1uFa+uUUd2zBfNQVK2KrbzWISquCzYVF5WVehHVtA==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/input/-/input-1.4.4.tgz",
+      "integrity": "sha512-A1TYz8lOdSVuMnWRnR7Y+cddnnr5d2o1Vvd8Im09WW2j09xy06xD/EaFy8dI51Ab0ACldglVs66qx5dO7WoV0w==",
       "requires": {
-        "@chakra-ui/form-control": "1.2.2",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/form-control": "1.5.9",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/utils": "1.10.4"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/layout": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/layout/-/layout-1.3.2.tgz",
-      "integrity": "sha512-L2dM3yRu2RKkENpuTiuBxz9Vq07LDhIWLo3aeB7uSbjWNi4kD8pVsHUw4489xEUVnVplC1T4XryM4gDck7jIVg==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/layout/-/layout-1.7.7.tgz",
+      "integrity": "sha512-HuZ/Zv9xWzLip263tX2Vt0oaqwaS6Srw78Sdl3DiGSifN8x+ooEAxmeDAIaU2PO21YX+f6s+9A738NAtSM2R+Q==",
       "requires": {
-        "@chakra-ui/icon": "1.1.2",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/icon": "2.0.5",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/utils": "1.10.4"
       },
       "dependencies": {
         "@chakra-ui/icon": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-1.1.2.tgz",
-          "integrity": "sha512-Gp/G0CZ8X8RWJWrs8jUm1dfA+5lS4zgNd078zQAj+yppnyhRGEGuZ6jAVJowtF+gbljZttmZwfXUgV3WpKnT/A==",
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-2.0.5.tgz",
+          "integrity": "sha512-ZrqRvCCIxGr4qFd/r1pmtd9tobRmv8KAxV7ygFoc/t4vOSKTcVIjhE12gsI3FzgvXM15ZFVwsxa1zodwgo5neQ==",
           "requires": {
-            "@chakra-ui/utils": "1.3.0"
+            "@chakra-ui/utils": "1.10.4"
           }
         },
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/live-region": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/live-region/-/live-region-1.0.5.tgz",
-      "integrity": "sha512-2DBI1wgTcXILW+pEceZwWDK1DbzIS/dNBCZVjkiE2ZT17rxjkl1/olq/em4jaNvlXGcZ9V0EjmiVO3NFM3mFmA==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/live-region/-/live-region-1.1.6.tgz",
+      "integrity": "sha512-9gPQHXf7oW0jXyT5R/JzyDMfJ3hF70TqhN8bRH4fMyfNr2Se+SjztMBqCrv5FS5rPjcCeua+e0eArpoB3ROuWQ==",
       "requires": {
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/utils": "1.10.4"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/media-query": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/media-query/-/media-query-1.0.6.tgz",
-      "integrity": "sha512-CRav7owkwkLBJC96vwZjlOpU4igQoZvDFd7aH/u9KivGg3saICtSfHwWPl58WIrowTIkvV5ycHyo0efzcB1S1Q==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/media-query/-/media-query-2.0.4.tgz",
+      "integrity": "sha512-kn6g/L0IFFUHz2v4yiCsBnhg9jUeA7525Z+AWl+BPtvryi7i9J+AJ27y/QAge7vUGy4dwDeFyxOZTs2oZ9/BsA==",
       "requires": {
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/react-env": "1.1.6",
+        "@chakra-ui/utils": "1.10.4"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/menu": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/menu/-/menu-1.1.3.tgz",
-      "integrity": "sha512-tO98inArQCg0nlMgl+9uL9YwN09AClmP3HZtGk/kINTvFD/eqKI/UDh/IcBhlHw5DczPKQtBBWO8yg2z7PqGPg==",
+      "version": "1.8.9",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/menu/-/menu-1.8.9.tgz",
+      "integrity": "sha512-rvQQU56nQoaz+IZXyamKaAU/87IiGIDrX9wEONHth7QDT/93whnFNYPtUMHMzILz0oliysBey4dlmtRzk5vUpQ==",
       "requires": {
-        "@chakra-ui/clickable": "1.0.5",
-        "@chakra-ui/descendant": "1.0.8",
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/popper": "1.1.5",
-        "@chakra-ui/transition": "1.0.9",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/clickable": "1.2.6",
+        "@chakra-ui/descendant": "2.1.3",
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/popper": "2.4.3",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/transition": "1.4.7",
+        "@chakra-ui/utils": "1.10.4"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/modal": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/modal/-/modal-1.6.1.tgz",
-      "integrity": "sha512-Eu2jp2aXrrmaLe+xAqdRQRXdmsMmQMu52gvunYRDoR94oGlKyhixMrxTZrATjq5+JNCV1D1QbwFhh+GvZhjbcg==",
+      "version": "1.10.10",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/modal/-/modal-1.10.10.tgz",
+      "integrity": "sha512-/OLnZhhGXQEaCqtrCCf2nu27mVxT/3Kd+NBNMKGZ4X70Dm6HD3x1Zrsto2hVo8l3kLEPRpkfpXhKu61doMc8zw==",
       "requires": {
-        "@chakra-ui/close-button": "1.1.2",
-        "@chakra-ui/focus-lock": "1.1.1",
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/portal": "1.1.2",
-        "@chakra-ui/transition": "1.0.9",
-        "@chakra-ui/utils": "1.3.0",
+        "@chakra-ui/close-button": "1.2.7",
+        "@chakra-ui/focus-lock": "1.2.6",
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/portal": "1.3.8",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/transition": "1.4.7",
+        "@chakra-ui/utils": "1.10.4",
         "aria-hidden": "^1.1.1",
         "react-remove-scroll": "2.4.1"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/number-input": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/number-input/-/number-input-1.1.2.tgz",
-      "integrity": "sha512-bSiX1cgE7tTJpuaYAqzhheU3F6S+WjlxY7tsJ842KoN8aooMFaB6VClkkjZAQfvCeXLXyYNlDi+FZwlwQq8j3Q==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/number-input/-/number-input-1.4.5.tgz",
+      "integrity": "sha512-jxOvJUEuXZXQrOgMGZ+rPNjSrIoV7MSb7CPt3C1jVuiumr/GgNu54awmrky3Zj4ikj68rREEUXAGKBgm9oU3nQ==",
       "requires": {
-        "@chakra-ui/counter": "1.0.8",
-        "@chakra-ui/form-control": "1.2.2",
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/icon": "1.1.2",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/counter": "1.2.8",
+        "@chakra-ui/form-control": "1.5.9",
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/icon": "2.0.5",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/utils": "1.10.4"
       },
       "dependencies": {
         "@chakra-ui/icon": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-1.1.2.tgz",
-          "integrity": "sha512-Gp/G0CZ8X8RWJWrs8jUm1dfA+5lS4zgNd078zQAj+yppnyhRGEGuZ6jAVJowtF+gbljZttmZwfXUgV3WpKnT/A==",
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-2.0.5.tgz",
+          "integrity": "sha512-ZrqRvCCIxGr4qFd/r1pmtd9tobRmv8KAxV7ygFoc/t4vOSKTcVIjhE12gsI3FzgvXM15ZFVwsxa1zodwgo5neQ==",
           "requires": {
-            "@chakra-ui/utils": "1.3.0"
+            "@chakra-ui/utils": "1.10.4"
           }
         },
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/pin-input": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/pin-input/-/pin-input-1.4.1.tgz",
-      "integrity": "sha512-0DY+q71VBbjmLh/soUcibj9Mi5+Jr0eKugRP8hzx1ywoSqmNVa4hhw12cC4xeEaO242Ec3752D7TLGCSZFD04Q==",
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/pin-input/-/pin-input-1.7.8.tgz",
+      "integrity": "sha512-P4uJBVKDxTetQhj+s0L7TbUTTqbcHwkLpo4bGUEdQpHMfGFlJgGu0wFT5Z8O0fw+vGNfguFfkqkVRRgK8FkHlA==",
       "requires": {
-        "@chakra-ui/descendant": "1.0.8",
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/descendant": "2.1.3",
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/utils": "1.10.4"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/popover": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/popover/-/popover-1.2.3.tgz",
-      "integrity": "sha512-hA44W7GwDpQWep5R+4lRkN9C3FE7zW+cTYuJXNNx2CwpUOWCdTAaPwx4LJb+yLmTMbRXDKSR1KrkzWK3C6Abcg==",
+      "version": "1.11.7",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/popover/-/popover-1.11.7.tgz",
+      "integrity": "sha512-TjMZlpBomIuGuQgGQi2rTSVFwFbc9HdJSU3anyFyDQb4ZnunyqaIEMoqFdj/dK8tDdWIatozKjX6AzSimmSvLg==",
       "requires": {
-        "@chakra-ui/close-button": "1.1.2",
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/popper": "1.1.5",
-        "@chakra-ui/portal": "1.1.2",
-        "@chakra-ui/transition": "1.0.9",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/close-button": "1.2.7",
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/popper": "2.4.3",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/utils": "1.10.4"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/popper": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/popper/-/popper-1.1.5.tgz",
-      "integrity": "sha512-Z7NpOMoycnELII8TTEC1FmMqAIO69xJ8pyNL4lo/ifNyTngIuEQw4o40U7rfA4E7A6AM24WmlgwH0lxFOfOqqg==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/popper/-/popper-2.4.3.tgz",
+      "integrity": "sha512-TGzFnYt3mtIVkIejtYIAu4Ka9DaYLzMR4NgcqI6EtaTvgK7Xep+6RTiY/Nq+ZT3l/eaNUwqHRFoNrDUg1XYasA==",
       "requires": {
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/utils": "1.3.0",
-        "@popperjs/core": "2.4.4",
-        "dequal": "2.0.2"
-      },
-      "dependencies": {
-        "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
-          "requires": {
-            "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
-            "css-box-model": "1.2.1",
-            "lodash.mergewith": "4.6.2"
-          }
-        }
+        "@chakra-ui/react-utils": "1.2.3",
+        "@popperjs/core": "^2.9.3"
       }
     },
     "@chakra-ui/portal": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/portal/-/portal-1.1.2.tgz",
-      "integrity": "sha512-cGZgevVcSC59egLn++nJ2RifrDGzVSZfY8DDpDaoeb7hLqa9w+zWjcMq54+BTHDIJ4PeRjZtnk1gl16KG4V8iQ==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/portal/-/portal-1.3.8.tgz",
+      "integrity": "sha512-rpSu/RdtlKfOBzw11qHs91IwUTffUfppBz33PfOFNZpDGmO0+6pWkz40I16eSgYtQigZRQG1spz6Ul7tsh+1ag==",
       "requires": {
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/utils": "1.10.4"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/progress": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/progress/-/progress-1.1.2.tgz",
-      "integrity": "sha512-ndxmLq5SF/yaOmDaGPeBuaDelDu3mtf0nzJcCKTVGjLIksTNUt71puQNsTEHGXp089wJlFKJLKAx2i0UqgasWA==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/progress/-/progress-1.2.6.tgz",
+      "integrity": "sha512-thaHRIYTVktgV78vJMNwzfCX+ickhSpn2bun6FtGVUphFx4tjV+ggz+IGohm6AH2hapskoR1mQU2iNZb6BK0hQ==",
       "requires": {
-        "@chakra-ui/theme-tools": "1.1.0",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/theme-tools": "1.3.6",
+        "@chakra-ui/utils": "1.10.4"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
+            "lodash.mergewith": "4.6.2"
+          }
+        }
+      }
+    },
+    "@chakra-ui/provider": {
+      "version": "1.7.12",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/provider/-/provider-1.7.12.tgz",
+      "integrity": "sha512-SSq4z4nMjCbqdGrRkbxzR4o96uRah1HnSFui3lM2263zJN7fyezqiseRboID+i7eIUCBWHMLdsabARAD8t1tDQ==",
+      "requires": {
+        "@chakra-ui/css-reset": "1.1.3",
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/portal": "1.3.8",
+        "@chakra-ui/react-env": "1.1.6",
+        "@chakra-ui/system": "1.11.2",
+        "@chakra-ui/utils": "1.10.4"
+      },
+      "dependencies": {
+        "@chakra-ui/utils": {
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
+          "requires": {
+            "@types/lodash.mergewith": "4.6.6",
+            "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/radio": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/radio/-/radio-1.2.4.tgz",
-      "integrity": "sha512-nf9haPcD2jX50XbaiSP5mJUZUUP0wKJSeHeCgMsPtTSMjmQcsr8V8qZ3s31uvy3K17KfPhxChtH7MvDHBNDHsQ==",
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/radio/-/radio-1.4.10.tgz",
+      "integrity": "sha512-TgqBgfezypC4do1Vj4iBp4kptXVWdnhASJ97VFuau2QQPT6zKl3Ke2di+XLhH3CZNCDHpvU/KxQNJ6bfj5GMGg==",
       "requires": {
-        "@chakra-ui/form-control": "1.2.2",
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/utils": "1.3.0",
-        "@chakra-ui/visually-hidden": "1.0.5"
+        "@chakra-ui/form-control": "1.5.9",
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/utils": "1.10.4",
+        "@chakra-ui/visually-hidden": "1.1.6"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/react": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-1.3.4.tgz",
-      "integrity": "sha512-RLj+PswKfJ14TTxhmqQeXmCREwoF36QivH0hKt6mu9BeGux5su8hbxcRwfZc+QW7pqyHIy17w0AqVGn79U7uDA==",
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-1.8.6.tgz",
+      "integrity": "sha512-FEh/KG0uPeNOMQuIlyPfGjHvGB7LN1AAhkdFefqzNt0zNy8Giv4p1PKY7wdCh5QEFor++A83L1wIWvTGQVJ2vQ==",
       "requires": {
-        "@chakra-ui/accordion": "1.1.3",
-        "@chakra-ui/alert": "1.1.2",
-        "@chakra-ui/avatar": "1.1.3",
-        "@chakra-ui/breadcrumb": "1.1.2",
-        "@chakra-ui/button": "1.1.3",
-        "@chakra-ui/checkbox": "1.2.4",
-        "@chakra-ui/close-button": "1.1.2",
-        "@chakra-ui/control-box": "1.0.5",
-        "@chakra-ui/counter": "1.0.8",
-        "@chakra-ui/css-reset": "1.0.0",
-        "@chakra-ui/editable": "1.1.2",
-        "@chakra-ui/form-control": "1.2.2",
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/icon": "1.1.2",
-        "@chakra-ui/image": "1.0.8",
-        "@chakra-ui/input": "1.1.3",
-        "@chakra-ui/layout": "1.3.2",
-        "@chakra-ui/live-region": "1.0.5",
-        "@chakra-ui/media-query": "1.0.6",
-        "@chakra-ui/menu": "1.1.3",
-        "@chakra-ui/modal": "1.6.1",
-        "@chakra-ui/number-input": "1.1.2",
-        "@chakra-ui/pin-input": "1.4.1",
-        "@chakra-ui/popover": "1.2.3",
-        "@chakra-ui/popper": "1.1.5",
-        "@chakra-ui/portal": "1.1.2",
-        "@chakra-ui/progress": "1.1.2",
-        "@chakra-ui/radio": "1.2.4",
-        "@chakra-ui/select": "1.1.2",
-        "@chakra-ui/skeleton": "1.1.4",
-        "@chakra-ui/slider": "1.1.2",
-        "@chakra-ui/spinner": "1.1.2",
-        "@chakra-ui/stat": "1.1.2",
-        "@chakra-ui/switch": "1.1.4",
-        "@chakra-ui/system": "1.4.0",
-        "@chakra-ui/table": "1.1.2",
-        "@chakra-ui/tabs": "1.2.0",
-        "@chakra-ui/tag": "1.1.2",
-        "@chakra-ui/textarea": "1.1.2",
-        "@chakra-ui/theme": "1.7.0",
-        "@chakra-ui/toast": "1.1.12",
-        "@chakra-ui/tooltip": "1.1.3",
-        "@chakra-ui/transition": "1.0.9",
-        "@chakra-ui/utils": "1.3.0",
-        "@chakra-ui/visually-hidden": "1.0.5"
+        "@chakra-ui/accordion": "1.4.9",
+        "@chakra-ui/alert": "1.3.7",
+        "@chakra-ui/avatar": "1.3.9",
+        "@chakra-ui/breadcrumb": "1.3.6",
+        "@chakra-ui/button": "1.5.8",
+        "@chakra-ui/checkbox": "1.6.8",
+        "@chakra-ui/close-button": "1.2.7",
+        "@chakra-ui/control-box": "1.1.6",
+        "@chakra-ui/counter": "1.2.8",
+        "@chakra-ui/css-reset": "1.1.3",
+        "@chakra-ui/editable": "1.4.0",
+        "@chakra-ui/form-control": "1.5.9",
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/icon": "2.0.5",
+        "@chakra-ui/image": "1.1.8",
+        "@chakra-ui/input": "1.4.4",
+        "@chakra-ui/layout": "1.7.7",
+        "@chakra-ui/live-region": "1.1.6",
+        "@chakra-ui/media-query": "2.0.4",
+        "@chakra-ui/menu": "1.8.9",
+        "@chakra-ui/modal": "1.10.10",
+        "@chakra-ui/number-input": "1.4.5",
+        "@chakra-ui/pin-input": "1.7.8",
+        "@chakra-ui/popover": "1.11.7",
+        "@chakra-ui/popper": "2.4.3",
+        "@chakra-ui/portal": "1.3.8",
+        "@chakra-ui/progress": "1.2.6",
+        "@chakra-ui/provider": "1.7.12",
+        "@chakra-ui/radio": "1.4.10",
+        "@chakra-ui/react-env": "1.1.6",
+        "@chakra-ui/select": "1.2.9",
+        "@chakra-ui/skeleton": "1.2.12",
+        "@chakra-ui/slider": "1.5.9",
+        "@chakra-ui/spinner": "1.2.6",
+        "@chakra-ui/stat": "1.2.7",
+        "@chakra-ui/switch": "1.3.8",
+        "@chakra-ui/system": "1.11.2",
+        "@chakra-ui/table": "1.3.6",
+        "@chakra-ui/tabs": "1.6.8",
+        "@chakra-ui/tag": "1.2.7",
+        "@chakra-ui/textarea": "1.2.9",
+        "@chakra-ui/theme": "1.14.0",
+        "@chakra-ui/toast": "1.5.7",
+        "@chakra-ui/tooltip": "1.4.9",
+        "@chakra-ui/transition": "1.4.7",
+        "@chakra-ui/utils": "1.10.4",
+        "@chakra-ui/visually-hidden": "1.1.6"
       },
       "dependencies": {
         "@chakra-ui/icon": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-1.1.2.tgz",
-          "integrity": "sha512-Gp/G0CZ8X8RWJWrs8jUm1dfA+5lS4zgNd078zQAj+yppnyhRGEGuZ6jAVJowtF+gbljZttmZwfXUgV3WpKnT/A==",
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-2.0.5.tgz",
+          "integrity": "sha512-ZrqRvCCIxGr4qFd/r1pmtd9tobRmv8KAxV7ygFoc/t4vOSKTcVIjhE12gsI3FzgvXM15ZFVwsxa1zodwgo5neQ==",
           "requires": {
-            "@chakra-ui/utils": "1.3.0"
+            "@chakra-ui/utils": "1.10.4"
           }
         },
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
+            "lodash.mergewith": "4.6.2"
+          }
+        }
+      }
+    },
+    "@chakra-ui/react-env": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-env/-/react-env-1.1.6.tgz",
+      "integrity": "sha512-L90LNvCfe04FTkN9OPok/o2e60zLJNBH8Im/5dUHvqy7dXLXok8ZDad5vEL46XmGbhe7O8fbxhG6FmAYdcCHrQ==",
+      "requires": {
+        "@chakra-ui/utils": "1.10.4"
+      },
+      "dependencies": {
+        "@chakra-ui/utils": {
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
+          "requires": {
+            "@types/lodash.mergewith": "4.6.6",
+            "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
+            "lodash.mergewith": "4.6.2"
+          }
+        }
+      }
+    },
+    "@chakra-ui/react-utils": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-utils/-/react-utils-1.2.3.tgz",
+      "integrity": "sha512-r8pUwCVVB7UPhb0AiRa9ZzSp4xkMz64yIeJ4O4aGy4WMw7TRH4j4QkbkE1YC9tQitrXrliOlvx4WWJR4VyiGpw==",
+      "requires": {
+        "@chakra-ui/utils": "^1.10.4"
+      },
+      "dependencies": {
+        "@chakra-ui/utils": {
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
+          "requires": {
+            "@types/lodash.mergewith": "4.6.6",
+            "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/select": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/select/-/select-1.1.2.tgz",
-      "integrity": "sha512-iN1oarmhBGdLc/MuExyymPsbGBKXTcw/ubkhTgYydGbiyOo8LkYtpzK4tfXyAJEI1banH5kZ7/DxLACqplaamw==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/select/-/select-1.2.9.tgz",
+      "integrity": "sha512-f8cRy3whXFYviuKGfugPnvXTGarPVt2ux5pffipmliYOhfaJ8O2OtdmNJ/od4WaeGStUH13x12GsEqVw2LBKOg==",
       "requires": {
-        "@chakra-ui/form-control": "1.2.2",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/form-control": "1.5.9",
+        "@chakra-ui/utils": "1.10.4"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/skeleton": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/skeleton/-/skeleton-1.1.4.tgz",
-      "integrity": "sha512-Dp4dmZ1TJRcqoXmRoGQxWI8q2yEPpTCeJquKmmJlca1pHghu9iIfLNdeJ0uZTw5xvm/PO0LIlNc8Kkyw1thMxQ==",
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/skeleton/-/skeleton-1.2.12.tgz",
+      "integrity": "sha512-buHqfKw24+EQXFGHlSRq2obHxZgz0FUKSFNMlQS3tMoFwBkLRO/jAQfjj9KKR5b0m2qu1qLBmwFHJLih1+bnzg==",
       "requires": {
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/media-query": "1.0.6",
-        "@chakra-ui/system": "1.4.0",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/media-query": "2.0.4",
+        "@chakra-ui/system": "1.11.2",
+        "@chakra-ui/utils": "1.10.4"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/slider": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/slider/-/slider-1.1.2.tgz",
-      "integrity": "sha512-ag5Dr6sXeakcQa+XLtpCM7GVwcZIjhFJt+DkdbxO2dVjUmtJSsAvCBdCUzM63HFzsZTD61RaOXSMWWLcyZ6Rrw==",
+      "version": "1.5.9",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/slider/-/slider-1.5.9.tgz",
+      "integrity": "sha512-m9n/BpnD/hEDS9q3T17ezgTFWDdvCocPzxQXzLLDN2Z2xOgwyLTQVLk4iB1yROvLCUl7Ig9C4+a4/7fivm+IHw==",
       "requires": {
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/utils": "1.10.4"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/spinner": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/spinner/-/spinner-1.1.2.tgz",
-      "integrity": "sha512-WZj+XcxXjWPWSjoJoeFupy2RDVqAVqIxFAylFolQ3mhmIAYDSBN6t1lUsSKxl8fWK1lSOAGxTOlvsI6eobMM/w==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/spinner/-/spinner-1.2.6.tgz",
+      "integrity": "sha512-GoUCccN120fGRVgUtfuwcEjeoaxffB+XsgpxX7jhWloXf8b6lkqm68bsxX4Ybb2vGN1fANI98/45JmrnddZO/A==",
       "requires": {
-        "@chakra-ui/utils": "1.3.0",
-        "@chakra-ui/visually-hidden": "1.0.5"
+        "@chakra-ui/utils": "1.10.4",
+        "@chakra-ui/visually-hidden": "1.1.6"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/stat": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/stat/-/stat-1.1.2.tgz",
-      "integrity": "sha512-Iw61iJY8ffx1miB+BOOw6Mnnuic3lD8tepxn8GdUrr+6liBreYbbEe9+VGZeaeU5qx9FDpjr8EtwzzHjKe/X7g==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/stat/-/stat-1.2.7.tgz",
+      "integrity": "sha512-m76jumFW1N+mCG4ytrUz9Mh09nZtS4OQcADEvOslfdI5StwwuzasTA1tueaelPzdhBioMwFUWL05Fr1fXbPJ/Q==",
       "requires": {
-        "@chakra-ui/icon": "1.1.2",
-        "@chakra-ui/utils": "1.3.0",
-        "@chakra-ui/visually-hidden": "1.0.5"
+        "@chakra-ui/icon": "2.0.5",
+        "@chakra-ui/utils": "1.10.4",
+        "@chakra-ui/visually-hidden": "1.1.6"
       },
       "dependencies": {
         "@chakra-ui/icon": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-1.1.2.tgz",
-          "integrity": "sha512-Gp/G0CZ8X8RWJWrs8jUm1dfA+5lS4zgNd078zQAj+yppnyhRGEGuZ6jAVJowtF+gbljZttmZwfXUgV3WpKnT/A==",
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-2.0.5.tgz",
+          "integrity": "sha512-ZrqRvCCIxGr4qFd/r1pmtd9tobRmv8KAxV7ygFoc/t4vOSKTcVIjhE12gsI3FzgvXM15ZFVwsxa1zodwgo5neQ==",
           "requires": {
-            "@chakra-ui/utils": "1.3.0"
+            "@chakra-ui/utils": "1.10.4"
           }
         },
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/styled-system": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-1.8.0.tgz",
-      "integrity": "sha512-EKtVaZSW3drOxNBV/Cl3Int3YN9o7BJ9WOsPBcXfdXjAsk5XORN74Mw8HVHPvcheW0ERTlOFWlTSv4Ot/U8GXg==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-1.18.1.tgz",
+      "integrity": "sha512-uhWMNAfkk1DFAQ4nKu+t23WBQ1/XSJq8Y3sBZJQpvopfwOcarbVvEiM5voSUWPA7pkpD/BprGM7zjIRockUcmw==",
       "requires": {
-        "@chakra-ui/utils": "1.3.0",
-        "csstype": "^3.0.6"
+        "@chakra-ui/utils": "1.10.4",
+        "csstype": "^3.0.9"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
-        },
-        "csstype": {
-          "version": "3.0.7",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.7.tgz",
-          "integrity": "sha512-KxnUB0ZMlnUWCsx2Z8MUsr6qV6ja1w9ArPErJaJaF8a5SOWoHLIszeCTKGRGRgtLgYrs1E8CHkNSP1VZTTPc9g=="
         }
       }
     },
     "@chakra-ui/switch": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/switch/-/switch-1.1.4.tgz",
-      "integrity": "sha512-fqGq7s9Pn4r5o0h9PMM2U60ScJF/6tWefCYqftIiWYNAQek+Iak0sug/JRo2/tbKJq1Vd2kheHVo4eVYRqUVCQ==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/switch/-/switch-1.3.8.tgz",
+      "integrity": "sha512-xcsq4G9YUNRSp0F+XBDjeGZFlJeEdGJptuixk6PZjqRJYUyH+k2bk1bJ2Bv2bjvmkDCojI42MkvWTLHrOqp41A==",
       "requires": {
-        "@chakra-ui/checkbox": "1.2.4",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/checkbox": "1.6.8",
+        "@chakra-ui/utils": "1.10.4"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/system": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/system/-/system-1.4.0.tgz",
-      "integrity": "sha512-AvfrF/eVMYJEw5im6sXFcbkxCYQP6RrFcpSjcQ4aD71tfnqDCrlr6oQ8P+fugbrUpGSERoVWpQs1rK4LMTWNLg==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/system/-/system-1.11.2.tgz",
+      "integrity": "sha512-s4HGYVo86XuSav5PLfuVT26Y+l3ca/nQVF6QxS6YCNiUxdBlahlzsZz3yMz3MKp11voljnY8vj4z4dvOd2sjUQ==",
       "requires": {
-        "@chakra-ui/color-mode": "1.1.1",
-        "@chakra-ui/styled-system": "1.8.0",
-        "@chakra-ui/utils": "1.3.0",
+        "@chakra-ui/color-mode": "1.4.6",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/styled-system": "1.18.1",
+        "@chakra-ui/utils": "1.10.4",
         "react-fast-compare": "3.2.0"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/table": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/table/-/table-1.1.2.tgz",
-      "integrity": "sha512-buaWwNS8VCx3T6izWjmULuIIQKDitI6kObthGIhmG3OsJgkSuzKk5xypK4Oa1b2H03gQT/jGeuwfv8ejjzjITw==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/table/-/table-1.3.6.tgz",
+      "integrity": "sha512-7agZAgAeDFKviqStvixqnLAH54+setzhx67EztioZTr5Xu+6hQ4rotfJbu8L4i587pcbNg98kCEXEkidjw0XRQ==",
       "requires": {
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/utils": "1.10.4"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/tabs": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/tabs/-/tabs-1.2.0.tgz",
-      "integrity": "sha512-9yorwUbbEqL6b+vDGvbAmOJTucLpC+pHxKCWFHub1DuZNXHKfqVZcBYYKWPVs0ydzVHCwxd0RRmhqtWAP8n0vQ==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/tabs/-/tabs-1.6.8.tgz",
+      "integrity": "sha512-f1kM9VhAXqKzTAVRoPRIINNiUgvBcadP9m5GtjAgE4DzCrQKnTDImjIkFhXlMvWEmB5ynXZcCGlsgIZ2A9Hs9g==",
       "requires": {
-        "@chakra-ui/clickable": "1.0.5",
-        "@chakra-ui/descendant": "1.0.8",
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/clickable": "1.2.6",
+        "@chakra-ui/descendant": "2.1.3",
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/utils": "1.10.4"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/tag": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/tag/-/tag-1.1.2.tgz",
-      "integrity": "sha512-oEGQSll4is63lulTkRwsL4QAOo6iHYaOL0gqSRQmHmHfeDBVNdxvaedN3mnxPPP8oFO8pKGJ9LqcaHe1pj7rTg==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/tag/-/tag-1.2.7.tgz",
+      "integrity": "sha512-RKrKOol4i/CnpFfo3T9LMm1abaqM+5Bs0soQLbo1iJBbBACY09sWXrQYvveQ2GYzU/OrAUloHqqmKjyVGOlNtg==",
       "requires": {
-        "@chakra-ui/icon": "1.1.2",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/icon": "2.0.5",
+        "@chakra-ui/utils": "1.10.4"
       },
       "dependencies": {
         "@chakra-ui/icon": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-1.1.2.tgz",
-          "integrity": "sha512-Gp/G0CZ8X8RWJWrs8jUm1dfA+5lS4zgNd078zQAj+yppnyhRGEGuZ6jAVJowtF+gbljZttmZwfXUgV3WpKnT/A==",
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-2.0.5.tgz",
+          "integrity": "sha512-ZrqRvCCIxGr4qFd/r1pmtd9tobRmv8KAxV7ygFoc/t4vOSKTcVIjhE12gsI3FzgvXM15ZFVwsxa1zodwgo5neQ==",
           "requires": {
-            "@chakra-ui/utils": "1.3.0"
+            "@chakra-ui/utils": "1.10.4"
           }
         },
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/textarea": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/textarea/-/textarea-1.1.2.tgz",
-      "integrity": "sha512-yltPY89AbFYKIvyVhj3h2yb5sglkxF6WigNmV/vn3LB2ZTxM0ozTj1rdgPC6LW48UIzRcW9F70L5N77SW0UfAQ==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/textarea/-/textarea-1.2.9.tgz",
+      "integrity": "sha512-HHeUdBA2JrH/S4PopcpOjRmBWKv4wpxQ+Q4mD03UBznyFARZe3XFJOnxhAPdpB/ZadbdgiyXK27TR0uzaqlONw==",
       "requires": {
-        "@chakra-ui/form-control": "1.2.2",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/form-control": "1.5.9",
+        "@chakra-ui/utils": "1.10.4"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/theme": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/theme/-/theme-1.7.0.tgz",
-      "integrity": "sha512-3GqSBOfKrgyq2SZ+Rv6YEFOvhKlyUPh4yCsPq0JpT5fbZjaVPS4zkcoUSqcNzEOyDI4Fb5NYtqhdGWVnLOPDcg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme/-/theme-1.14.0.tgz",
+      "integrity": "sha512-zKy/8JSbiCP0QeBsLzdub7aBnfX2k0qp5vD+RA+mxPEiykEvPGg+TwryxRM5KMZK1Zdgg95aH+9mwiGe9tJt3A==",
       "requires": {
-        "@chakra-ui/theme-tools": "1.1.0",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/anatomy": "1.3.0",
+        "@chakra-ui/theme-tools": "1.3.6",
+        "@chakra-ui/utils": "1.10.4"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/theme-tools": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-tools/-/theme-tools-1.1.0.tgz",
-      "integrity": "sha512-o1rJBJj3vbhq4C02Ld9Ay1xXKrfphQAqDacowKQlRu8G5DL+EvH/v0RGLkdJQd1ORoUsUZrZBvOcXO9dQt9DeQ==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-tools/-/theme-tools-1.3.6.tgz",
+      "integrity": "sha512-Wxz3XSJhPCU6OwCHEyH44EegEDQHwvlsx+KDkUDGevOjUU88YuNqOVkKtgTpgMLNQcsrYZ93oPWZUJqqCVNRew==",
       "requires": {
-        "@chakra-ui/utils": "1.3.0",
-        "@types/tinycolor2": "1.4.2",
-        "tinycolor2": "1.4.2"
+        "@chakra-ui/utils": "1.10.4",
+        "@ctrl/tinycolor": "^3.4.0"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/toast": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/toast/-/toast-1.1.12.tgz",
-      "integrity": "sha512-mLc8mB5mp34UXGD+XKmBYUUiB1dIZtD9AXkLbfeTwMPIsm52vCMk73CnZByr26G8HZM1wXLQF3/UO/1PzeWOug==",
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/toast/-/toast-1.5.7.tgz",
+      "integrity": "sha512-vM88vX2jTfSwOXWqcj9o9pm+msojJS0cG0Pe/wSuYP+D274SdE8oB2OFqJyijsQ7WQq/P6BIlgquzUcS4smu9A==",
       "requires": {
-        "@chakra-ui/alert": "1.1.2",
-        "@chakra-ui/close-button": "1.1.2",
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/theme": "1.7.0",
-        "@chakra-ui/transition": "1.0.9",
-        "@chakra-ui/utils": "1.3.0",
-        "@reach/alert": "0.13.0"
+        "@chakra-ui/alert": "1.3.7",
+        "@chakra-ui/close-button": "1.2.7",
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/theme": "1.14.0",
+        "@chakra-ui/transition": "1.4.7",
+        "@chakra-ui/utils": "1.10.4",
+        "@reach/alert": "0.13.2"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/tooltip": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/tooltip/-/tooltip-1.1.3.tgz",
-      "integrity": "sha512-wYEezJnMkYT23mwV+NS4cwG5+xOgoPdQ2YBDaOAOHGmX5wX4gZ9YjC9t17MunvFt4hknvjMhtujUSjaYHMSqxA==",
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/tooltip/-/tooltip-1.4.9.tgz",
+      "integrity": "sha512-W1GVMFWkLLBfiFsOddhr7oWr2rTKqSy2xxMkR5MuomNaqORW4tvjN/wNSLMUuUHVxtWM+iRQkslE5r6k5/1HAw==",
       "requires": {
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/popper": "1.1.5",
-        "@chakra-ui/portal": "1.1.2",
-        "@chakra-ui/utils": "1.3.0",
-        "@chakra-ui/visually-hidden": "1.0.5"
+        "@chakra-ui/hooks": "1.8.5",
+        "@chakra-ui/popper": "2.4.3",
+        "@chakra-ui/portal": "1.3.8",
+        "@chakra-ui/react-utils": "1.2.3",
+        "@chakra-ui/utils": "1.10.4",
+        "@chakra-ui/visually-hidden": "1.1.6"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
       }
     },
     "@chakra-ui/transition": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/transition/-/transition-1.0.9.tgz",
-      "integrity": "sha512-ry7i3VY8xhfWxrOcHs4W7hpyT4HsL3P4qe8jbZICzVxuWL7rtYb26P+yItGJeeujE53m2wKjXqrE8kdSivaMVg==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/transition/-/transition-1.4.7.tgz",
+      "integrity": "sha512-2sbMoKB/enp6Qbte3DD6zwBHyO4YAUSgvSr3wn7DAy4hz9kRZHPuUf/N+i9QZ0whL2koXLgdZvV6RNtSTShq4g==",
       "requires": {
-        "@chakra-ui/hooks": "1.1.5",
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/utils": "1.10.4"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
@@ -21362,21 +21409,21 @@
       }
     },
     "@chakra-ui/visually-hidden": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/visually-hidden/-/visually-hidden-1.0.5.tgz",
-      "integrity": "sha512-EIRZ081CgfFqhnOuhTfoluoqaKtx1id3/oCLk9QrJcB3s3r3PWexg41/z0WUaQzeQSPobw3hz5M5QxymmrZ4UQ==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/visually-hidden/-/visually-hidden-1.1.6.tgz",
+      "integrity": "sha512-Xzy5bA0UA+IyMgwJizQYSEdgz8cC/tHdmFB3CniXzmpKTSK8mJddeEBl+cGbXHBzxEUhH7xF1eaS41O+0ezWEQ==",
       "requires": {
-        "@chakra-ui/utils": "1.3.0"
+        "@chakra-ui/utils": "1.10.4"
       },
       "dependencies": {
         "@chakra-ui/utils": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.3.0.tgz",
-          "integrity": "sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==",
+          "version": "1.10.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
+          "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
           "requires": {
             "@types/lodash.mergewith": "4.6.6",
-            "@types/object-assign": "4.0.30",
             "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
             "lodash.mergewith": "4.6.2"
           }
         }
@@ -21400,6 +21447,11 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-10.1.0.tgz",
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
+    },
+    "@ctrl/tinycolor": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.4.0.tgz",
+      "integrity": "sha512-JZButFdZ1+/xAfpguQHoabIXkcqRRKpMrWKBkpEZZyxfY9C1DpADFB8PEqGSTeFr135SaTRfKqGKx5xSCLI7ZQ=="
     },
     "@emotion/babel-plugin": {
       "version": "11.1.2",
@@ -21776,57 +21828,58 @@
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
     },
     "@popperjs/core": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.4.4.tgz",
-      "integrity": "sha512-1oO6+dN5kdIA3sKPZhRGJTfGVP4SWV6KqlMOwry4J3HfyD68sl/3KmG7DeYUzvN+RbhXDnv/D8vNNB8168tAMg=="
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.2.tgz",
+      "integrity": "sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA=="
     },
     "@reach/alert": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@reach/alert/-/alert-0.13.0.tgz",
-      "integrity": "sha512-5lpgRnlQ0JHBsRTPfKjD9aFPDZuLcaxTgD5PXdSLb+1CU8WgNbcy+7qSjqnu1uzWS2pQenIEBViV5wGpt63ADw==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@reach/alert/-/alert-0.13.2.tgz",
+      "integrity": "sha512-LDz83AXCrClyq/MWe+0vaZfHp1Ytqn+kgL5VxG7rirUvmluWaj/snxzfNPWn0Ma4K2YENmXXRC/iHt5X95SqIg==",
       "requires": {
-        "@reach/utils": "0.13.0",
-        "@reach/visually-hidden": "0.13.0",
+        "@reach/utils": "0.13.2",
+        "@reach/visually-hidden": "0.13.2",
         "prop-types": "^15.7.2",
-        "tslib": "^2.0.0"
+        "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         }
       }
     },
     "@reach/utils": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.13.0.tgz",
-      "integrity": "sha512-dypxuyA1Qy3LHxzzyS7jFGPgCCR04b8UEn+Tv/aj6y9V578dULQqkcCyobrdEa+OI8lxH7dFFHa+jH8M/noBrQ==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.13.2.tgz",
+      "integrity": "sha512-3ir6cN60zvUrwjOJu7C6jec/samqAeyAB12ZADK+qjnmQPdzSYldrFWwDVV5H0WkhbYXR3uh+eImu13hCetNPQ==",
       "requires": {
         "@types/warning": "^3.0.0",
-        "tslib": "^2.0.0",
+        "tslib": "^2.1.0",
         "warning": "^4.0.3"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         }
       }
     },
     "@reach/visually-hidden": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@reach/visually-hidden/-/visually-hidden-0.13.0.tgz",
-      "integrity": "sha512-LF11WL9/495Q3d86xNy0VO6ylPI6SqF2xZGg9jpZSXLbFKpQ5Bf0qC7DOJfSf+/yb9WgPgB4m+a48Fz8AO6oZA==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@reach/visually-hidden/-/visually-hidden-0.13.2.tgz",
+      "integrity": "sha512-sPZwNS0/duOuG0mYwE5DmgEAzW9VhgU3aIt1+mrfT/xiT9Cdncqke+kRBQgU708q/Ttm9tWsoHni03nn/SuPTQ==",
       "requires": {
-        "tslib": "^2.0.0"
+        "prop-types": "^15.7.2",
+        "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         }
       }
     },
@@ -22150,11 +22203,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw=="
-    },
-    "@types/tinycolor2": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@types/tinycolor2/-/tinycolor2-1.4.2.tgz",
-      "integrity": "sha512-PeHg/AtdW6aaIO2a+98Xj7rWY4KC1E6yOy7AFknJQ7VXUGNrMlyxDFxJo7HqLtjQms/ZhhQX52mLVW/EX3JGOw=="
     },
     "@types/warning": {
       "version": "3.0.0",
@@ -22587,9 +22635,9 @@
       }
     },
     "aria-hidden": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.1.2.tgz",
-      "integrity": "sha512-WAMH9q3vRimVqP+B0q2eDvx7IPDoY17A2fWwj5atTA/zTYJCNcS6HJ5YErZ5FO3PUHhrV0y0yR1NA0dRNm913A==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.1.3.tgz",
+      "integrity": "sha512-RhVWFtKH5BiGMycI72q2RAFMLQi8JP9bLuQXgR5a8Znp7P5KOIADSJeyfI8PCVxLEp067B2HbP5JIiI/PXIZeA==",
       "requires": {
         "tslib": "^1.0.0"
       }
@@ -24536,9 +24584,9 @@
       }
     },
     "csstype": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
-      "integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag=="
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz",
+      "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw=="
     },
     "cyclist": {
       "version": "1.0.1",
@@ -24739,11 +24787,6 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
-    "dequal": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
-      "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug=="
-    },
     "des.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
@@ -24769,9 +24812,9 @@
       "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
     },
     "detect-node-es": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.0.0.tgz",
-      "integrity": "sha512-S4AHriUkTX9FoFvL4G8hXDcx6t3gp2HpfCza3Q0v6S78gul2hKWifLQbeW+ZF89+hSm2ZIc/uF3J97ZgytgTRg=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
     "detect-port-alt": {
       "version": "1.1.6",
@@ -26210,11 +26253,18 @@
       }
     },
     "focus-lock": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.8.1.tgz",
-      "integrity": "sha512-/LFZOIo82WDsyyv7h7oc0MJF9ACOvDRdx9rWPZ2pgMfNWu/z8hQDBtOchuB/0BVLmuFOZjV02YwUVzNsWx/EzA==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.9.2.tgz",
+      "integrity": "sha512-YtHxjX7a0IC0ZACL5wsX8QdncXofWpGPNoVMuI/nZUrPGp6LmNI6+D5j0pPj+v8Kw5EpweA+T5yImK0rnWf7oQ==",
       "requires": {
-        "tslib": "^1.9.3"
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
       }
     },
     "follow-redirects": {
@@ -26286,24 +26336,38 @@
       }
     },
     "framer-motion": {
-      "version": "2.9.5",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-2.9.5.tgz",
-      "integrity": "sha512-epSX4Co1YbDv0mjfHouuY0q361TpHE7WQzCp/xMTilxy4kXd+Z23uJzPVorfzbm1a/9q1Yu8T5bndaw65NI4Tg==",
+      "version": "4.1.17",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-4.1.17.tgz",
+      "integrity": "sha512-thx1wvKzblzbs0XaK2X0G1JuwIdARcoNOW7VVwjO8BUltzXPyONGAElLu6CiCScsOQRI7FIk/45YTFtJw5Yozw==",
       "requires": {
         "@emotion/is-prop-valid": "^0.8.2",
-        "framesync": "^4.1.0",
+        "framesync": "5.3.0",
         "hey-listen": "^1.0.8",
-        "popmotion": "9.0.0-rc.20",
-        "style-value-types": "^3.1.9",
-        "tslib": "^1.10.0"
+        "popmotion": "9.3.6",
+        "style-value-types": "4.1.4",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
       }
     },
     "framesync": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/framesync/-/framesync-4.1.0.tgz",
-      "integrity": "sha512-MmgZ4wCoeVxNbx2xp5hN/zPDCbLSKiDt4BbbslK7j/pM2lg5S0vhTNv1v8BCVb99JPIo6hXBFdwzU7Q4qcAaoQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/framesync/-/framesync-5.3.0.tgz",
+      "integrity": "sha512-oc5m68HDO/tuK2blj7ZcdEBRx3p1PjrgHazL8GYEpvULhrtGIFbQArN6cQS2QhW8mitffaB+VYzMjDqBxxQeoA==",
       "requires": {
-        "hey-listen": "^1.0.5"
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
       }
     },
     "fresh": {
@@ -29534,14 +29598,21 @@
       }
     },
     "popmotion": {
-      "version": "9.0.0-rc.20",
-      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-9.0.0-rc.20.tgz",
-      "integrity": "sha512-f98sny03WuA+c8ckBjNNXotJD4G2utG/I3Q23NU69OEafrXtxxSukAaJBxzbtxwDvz3vtZK69pu9ojdkMoBNTg==",
+      "version": "9.3.6",
+      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-9.3.6.tgz",
+      "integrity": "sha512-ZTbXiu6zIggXzIliMi8LGxXBF5ST+wkpXGEjeTUDUOCdSQ356hij/xjeUdv0F8zCQNeqB1+PR5/BB+gC+QLAPw==",
       "requires": {
-        "framesync": "^4.1.0",
+        "framesync": "5.3.0",
         "hey-listen": "^1.0.8",
-        "style-value-types": "^3.1.9",
-        "tslib": "^1.10.0"
+        "style-value-types": "4.1.4",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
       }
     },
     "portfinder": {
@@ -30804,16 +30875,6 @@
       "integrity": "sha512-2bL8qFW1TGBHozGGbVeyvnggRpMjibeZM2536AKNENLECutp2yfs44IL8Hmpn8qjFQ2K7A9PnYf3vc7aQq/cPA==",
       "requires": {
         "@babel/runtime": "^7.12.13"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.13.10",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
-          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        }
       }
     },
     "react-dev-utils": {
@@ -31039,16 +31100,16 @@
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
     "react-focus-lock": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.5.0.tgz",
-      "integrity": "sha512-XLxj6uTXgz0US8TmqNU2jMfnXwZG0mH2r/afQqvPEaX6nyEll5LHVcEXk2XDUQ34RVeLPkO/xK5x6c/qiuSq/A==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.5.2.tgz",
+      "integrity": "sha512-WzpdOnEqjf+/A3EH9opMZWauag7gV0BxFl+EY4ElA4qFqYsUsBLnmo2sELbN5OC30S16GAWMy16B9DLPpdJKAQ==",
       "requires": {
         "@babel/runtime": "^7.0.0",
-        "focus-lock": "^0.8.1",
+        "focus-lock": "^0.9.1",
         "prop-types": "^15.6.2",
-        "react-clientside-effect": "^1.2.2",
-        "use-callback-ref": "^1.2.1",
-        "use-sidecar": "^1.0.1"
+        "react-clientside-effect": "^1.2.5",
+        "use-callback-ref": "^1.2.5",
+        "use-sidecar": "^1.0.5"
       }
     },
     "react-graph-vis": {
@@ -32665,12 +32726,19 @@
       }
     },
     "style-value-types": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-3.1.9.tgz",
-      "integrity": "sha512-050uqgB7WdvtgacoQKm+4EgKzJExVq0sieKBQQtJiU3Muh6MYcCp4T3M8+dfl6VOF2LR0NNwXBP1QYEed8DfIw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-4.1.4.tgz",
+      "integrity": "sha512-LCJL6tB+vPSUoxgUBt9juXIlNJHtBMy8jkXzUJSBzeHWdBu6lhzHqCvLVkXFGsFIlNa2ln1sQHya/gzaFmB2Lg==",
       "requires": {
         "hey-listen": "^1.0.8",
-        "tslib": "^1.10.0"
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
       }
     },
     "stylehacks": {
@@ -32975,11 +33043,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
       "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
-    },
-    "tinycolor2": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
-      "integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA=="
     },
     "tmp": {
       "version": "0.0.33",
@@ -33313,11 +33376,11 @@
       }
     },
     "use-sidecar": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.0.4.tgz",
-      "integrity": "sha512-A5ggIS3/qTdxCAlcy05anO2/oqXOfpmxnpRE1Jm+fHHtCvUvNSZDGqgOSAXPriBVAcw2fMFFkh5v5KqrFFhCMA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.0.5.tgz",
+      "integrity": "sha512-k9jnrjYNwN6xYLj1iaGhonDghfvmeTmYjAiGvOr7clwKfPjMXJf4/HOr7oT5tJwYafgp2tG2l3eZEOfoELiMcA==",
       "requires": {
-        "detect-node-es": "^1.0.0",
+        "detect-node-es": "^1.1.0",
         "tslib": "^1.9.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "private": true,
   "dependencies": {
     "@chakra-ui/icons": "^1.0.1",
-    "@chakra-ui/react": "^1.3.0",
+    "@chakra-ui/react": "^1.8.6",
     "@emotion/react": "^11.0.0",
     "@emotion/styled": "^11.0.0",
-    "framer-motion": "^2.9.5",
+    "framer-motion": "^4.1.17",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-graph-vis": "^1.0.7",

--- a/src/Node.js
+++ b/src/Node.js
@@ -24,7 +24,6 @@ class Node {
             this.requiere ? "\n- Requiere " + this.requiere + " créditos" : ""
           }`
         : `[${this.id}] ${this.materia}`);
-    this.cuatri = -1;
     this.cuatrimestre = undefined;
     this.level = this.level ?? -1;
     this.hidden =
@@ -36,14 +35,12 @@ class Node {
   aprobar(nota) {
     if (nota < -1) return;
     this.aprobada = nota > -1 ? true : false;
-    this.cuatri = -1;
     this.nota = nota;
     return this;
   }
 
   desaprobar() {
     this.aprobada = false;
-    this.cuatri = -1;
     this.nota = -2;
     return this;
   }
@@ -86,8 +83,6 @@ class Node {
     let grupoDefault = this.categoria;
     if (this.aprobada && this.nota >= 0) grupoDefault = "Aprobadas";
     else if (this.nota === -1) grupoDefault = "En Final";
-    else if (this.cuatri === 0) grupoDefault = "Cursando";
-    else if (this.cuatri > 0) grupoDefault = `A Cursar (${this.cuatri})`;
     else if (this.isHabilitada(ctx)) grupoDefault = "Habilitadas";
     this.group = grupoDefault;
 
@@ -98,10 +93,6 @@ class Node {
       else if (this.aprobada && this.nota === 0)
         labelDefault += "\n[Equivalencia]";
       else if (this.nota === -1) labelDefault += "\n[En Final]";
-      else if (this.cuatri === 0) labelDefault += "\n[Cursando]";
-      else if (this.cuatri === 1) labelDefault += "\n[En 1 cuatri]";
-      else if (this.cuatri > 1)
-        labelDefault += "\n[En " + this.cuatri + " cuatris]";
     }
     this.label = labelDefault;
 

--- a/src/Node.js
+++ b/src/Node.js
@@ -25,6 +25,7 @@ class Node {
           }`
         : `[${this.id}] ${this.materia}`);
     this.cuatri = -1;
+    this.cuatrimestre = undefined;
     this.level = this.level ?? -1;
     this.hidden =
       this.categoria !== "Materias Obligatorias" &&
@@ -48,9 +49,7 @@ class Node {
   }
 
   cursando(cuatri) {
-    this.aprobada = false;
-    this.cuatri = cuatri;
-    this.nota = -2;
+    this.cuatrimestre = cuatri;
     return this;
   }
 

--- a/src/Node.js
+++ b/src/Node.js
@@ -1,5 +1,8 @@
 import { COLORS } from "./theme";
 
+const FONT_AFUERA = ["CBC", "*CBC", "Fin de Carrera", "Fin de Carrera (Obligatorio)"]
+const ALWAYS_SHOW = ["Materias Obligatorias", "CBC", "Fin de Carrera (Obligatorio)"]
+
 function breakWords(string) {
   let broken = "";
   string.split(" ").forEach((element) => {
@@ -25,12 +28,9 @@ class Node {
           }`
         : `[${this.id}] ${this.materia}`);
     this.cuatrimestre = undefined;
-    this.originalLevel = this.level ?? -1;
-    this.level = this.originalLevel
-    this.hidden =
-      this.categoria !== "Materias Obligatorias" &&
-      this.categoria !== "CBC" &&
-      this.categoria !== "Fin de Carrera (Obligatorio)";
+    this.originalLevel = this.level;
+    this.level = this.level ?? -3
+    this.hidden = !ALWAYS_SHOW.includes(this.categoria)
   }
 
   aprobar(nota) {
@@ -100,7 +100,6 @@ class Node {
     if (this.categoria === "*CBC") {
       if (this.group === "Habilitadas") this.color = COLORS.aprobadas[100];
       if (this.group === "Aprobadas") this.color = COLORS.aprobadas[400];
-      this.font = { color: colorMode === "dark" ? "white" : "black" };
     }
 
     if (this.categoria === "CBC") {
@@ -119,78 +118,13 @@ class Node {
       if (showLabels && promedioCBC) this.label += "\n[" + promedioCBC + "]";
       if (materiasCBC.length === 6) this.color = COLORS.aprobadas[400];
       else this.color = COLORS.aprobadas[100];
-
-      this.font = { color: colorMode === "dark" ? "white" : "black" };
     }
 
     if (this.categoria === "Fin de Carrera") {
       this.hidden = !(this.id === user.finDeCarrera?.materia);
     }
 
-    const firstCuatrimestreSet = Math.min(
-      ...nodes
-        .get({
-          filter: (n) =>
-            !n.hidden &&
-            n.cuatrimestre &&
-            n.categoria !== "CBC" &&
-            n.categoria !== "*CBC" &&
-            n.categoria !== "Fin de Carrera" &&
-            n.categoria !== "Fin de Carrera (Obligatorio)",
-          fields: ["cuatrimestre"],
-          type: { cuatrimestre: "number" },
-        })
-        .map((n) => n.cuatrimestre)
-    );
-
-    const lastCuatrimestreSet = Math.max(
-      ...nodes
-        .get({
-          filter: (n) =>
-            !n.hidden &&
-            n.cuatrimestre &&
-            n.categoria !== "CBC" &&
-            n.categoria !== "*CBC" &&
-            n.categoria !== "Fin de Carrera" &&
-            n.categoria !== "Fin de Carrera (Obligatorio)",
-          fields: ["cuatrimestre"],
-          type: { cuatrimestre: "number" },
-        })
-        .map((n) => n.cuatrimestre)
-    );
-
-    if (this.cuatrimestre) {
-      this.level = ((this.cuatrimestre - firstCuatrimestreSet) / 0.5) + 1;
-    } else if (this.originalLevel !== -1) {
-      if (isFinite(lastCuatrimestreSet) && isFinite(firstCuatrimestreSet)) {
-        this.level = ((lastCuatrimestreSet - firstCuatrimestreSet) / 0.5) + this.originalLevel + 1;
-      }
-    }
-
-    if (
-      this.categoria === "CBC" ||
-      this.categoria === "*CBC"
-    ) {
-      this.level = this.originalLevel;
-    }
-
-    if (
-      this.categoria === "Fin de Carrera" ||
-      this.categoria === "Fin de Carrera (Obligatorio)"
-    ) {
-      const lastLevel = Math.max(
-        ...nodes
-          .get({
-            filter: (n) =>
-              !n.hidden &&
-              n.categoria !== "Fin de Carrera" &&
-              n.categoria !== "Fin de Carrera (Obligatorio)",
-            fields: ["level"],
-            type: { level: "number" },
-          })
-          .map((n) => n.level)
-      );
-      this.level = lastLevel + 1;
+    if (FONT_AFUERA.includes(this.categoria)) {
       this.font = { color: colorMode === "dark" ? "white" : "black" };
     }
 

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -76,7 +76,7 @@ const Footer = () => {
             mr={1}
             borderRadius={5}
             size="sm"
-            maxW={isEditing ? 16 : 12}
+            maxW={isEditing ? 16 : 14}
             defaultValue={defaultValue}
             min={1}
             onChange={(_, creditos) => {

--- a/src/components/MateriaMenu.js
+++ b/src/components/MateriaMenu.js
@@ -22,16 +22,8 @@ import { GraphContext } from "../Contexts";
 
 const Header = (props) => {
   const { displayedNode } = props;
-  const { getNode, aprobar, desaprobar, cursando } =
+  const { getNode, aprobar, desaprobar, cursando, getCurrentCuatri } =
     React.useContext(GraphContext);
-
-  const getCurrentCuatri = () => {
-    const today = new Date();
-    let cuatri = today.getFullYear();
-    const month = today.getMonth();
-    if (month > 6) cuatri = cuatri + 0.5;
-    return cuatri;
-  }
 
   const formatCuatri = (cuatristr) => {
     if (!cuatristr) return "/";
@@ -71,7 +63,7 @@ const Header = (props) => {
                 value={getNode(displayedNode)?.nota}
                 min={4}
                 max={10}
-                maxW={16}
+                maxW="4.5rem"
               >
                 <NumberInputField
                   _hover={{

--- a/src/components/MateriaMenu.js
+++ b/src/components/MateriaMenu.js
@@ -163,79 +163,81 @@ const Header = (props) => {
         </Tooltip>
       </Flex>
 
-      <HStack borderRadius={6} ml={2} border="2px solid white" height={"60%"}>
-        <Tooltip closeOnClick hasArrow label="Planear Cuatri">
-          <NumberInput
-            css={{ margin: 0 }}
-            errorBorderColor="white.500"
-            borderColor="transparent"
-            onChange={(_, cuatri) => {
-              cursando(displayedNode, cuatri);
-            }}
-            value={getNode(displayedNode)?.cuatrimestre}
-            format={formatCuatri}
-            parse={parseCuatri}
-            step={0.5}
-            precision={1}
-            key={getNode(displayedNode)?.cuatrimestre}
-            min={getNode(displayedNode)?.cuatrimestre ? 1986 : getCurrentCuatri()}
-            max={2050}
-          >
-            <NumberInputField
-              _hover={{
-                borderColor: "transparent",
+      {getNode(displayedNode).categoria !== "CBC" && getNode(displayedNode).categoria !== "*CBC" && (
+        <HStack borderRadius={6} ml={2} border="2px solid white" height={"60%"}>
+          <Tooltip closeOnClick hasArrow label="Planear Cuatri">
+            <NumberInput
+              css={{ margin: 0 }}
+              errorBorderColor="white.500"
+              borderColor="transparent"
+              onChange={(_, cuatri) => {
+                cursando(displayedNode, cuatri);
               }}
-              _focus={{
-                borderColor: "transparent",
-              }}
-              p={0}
-              ml={2}
-              w="10ch"
-              color="white"
-              fontWeight="bold"
-            />
-            <NumberInputStepper>
-              <NumberIncrementStepper
-                border="none"
+              value={getNode(displayedNode)?.cuatrimestre}
+              format={formatCuatri}
+              parse={parseCuatri}
+              step={0.5}
+              precision={1}
+              key={getNode(displayedNode)?.cuatrimestre}
+              min={getNode(displayedNode)?.cuatrimestre ? 1986 : getCurrentCuatri()}
+              max={2050}
+            >
+              <NumberInputField
+                _hover={{
+                  borderColor: "transparent",
+                }}
+                _focus={{
+                  borderColor: "transparent",
+                }}
+                p={0}
+                ml={2}
+                w="10ch"
                 color="white"
-                fontSize="large"
-                height="50%"
-                children={<strong>+</strong>}
+                fontWeight="bold"
               />
-              <NumberDecrementStepper
-                border="none"
-                color="grey"
-                fontSize="large"
-                height="50%"
-                children={<strong>-</strong>}
-              />
-            </NumberInputStepper>
-          </NumberInput>
-        </Tooltip>
+              <NumberInputStepper>
+                <NumberIncrementStepper
+                  border="none"
+                  color="white"
+                  fontSize="large"
+                  height="50%"
+                  children={<strong>+</strong>}
+                />
+                <NumberDecrementStepper
+                  border="none"
+                  color="grey"
+                  fontSize="large"
+                  height="50%"
+                  children={<strong>-</strong>}
+                />
+              </NumberInputStepper>
+            </NumberInput>
+          </Tooltip>
 
-        <Tooltip closeOnClick hasArrow label="Limpiar Cuatri">
-          <Button
-            _hover={{
-              backgroundColor: "transparent",
-            }}
-            borderRadius="0"
-            cursor="pointer"
-            variant="link"
-            borderLeft="2px solid white"
-            fontSize="larger"
-            color="white"
-            onClick={() => cursando(displayedNode, undefined)}
-          >
-            <Icon boxSize={5} viewBox="0 0 24 24">
-              <path
-                fill="currentColor"
-                d="M12.2071 2.29289C12.5976 2.68342 12.5976 3.31658 12.2071 3.70711L10.9142 5H12.5C17.1523 5 21 8.84772 21 13.5C21 18.1523 17.1523 22 12.5 22C7.84772 22 4 18.1523 4 13.5C4 12.9477 4.44772 12.5 5 12.5C5.55228 12.5 6 12.9477 6 13.5C6 17.0477 8.95228 20 12.5 20C16.0477 20 19 17.0477 19 13.5C19 9.95228 16.0477 7 12.5 7H10.9142L12.2071 8.29289C12.5976 8.68342 12.5976 9.31658 12.2071 9.70711C11.8166 10.0976 11.1834 10.0976 10.7929 9.70711L7.79289 6.70711C7.40237 6.31658 7.40237 5.68342 7.79289 5.29289L10.7929 2.29289C11.1834 1.90237 11.8166 1.90237 12.2071 2.29289Z"
-              />
-            </Icon>
+          <Tooltip closeOnClick hasArrow label="Limpiar Cuatri">
+            <Button
+              _hover={{
+                backgroundColor: "transparent",
+              }}
+              borderRadius="0"
+              cursor="pointer"
+              variant="link"
+              borderLeft="2px solid white"
+              fontSize="larger"
+              color="white"
+              onClick={() => cursando(displayedNode, undefined)}
+            >
+              <Icon boxSize={5} viewBox="0 0 24 24">
+                <path
+                  fill="currentColor"
+                  d="M12.2071 2.29289C12.5976 2.68342 12.5976 3.31658 12.2071 3.70711L10.9142 5H12.5C17.1523 5 21 8.84772 21 13.5C21 18.1523 17.1523 22 12.5 22C7.84772 22 4 18.1523 4 13.5C4 12.9477 4.44772 12.5 5 12.5C5.55228 12.5 6 12.9477 6 13.5C6 17.0477 8.95228 20 12.5 20C16.0477 20 19 17.0477 19 13.5C19 9.95228 16.0477 7 12.5 7H10.9142L12.2071 8.29289C12.5976 8.68342 12.5976 9.31658 12.2071 9.70711C11.8166 10.0976 11.1834 10.0976 10.7929 9.70711L7.79289 6.70711C7.40237 6.31658 7.40237 5.68342 7.79289 5.29289L10.7929 2.29289C11.1834 1.90237 11.8166 1.90237 12.2071 2.29289Z"
+                />
+              </Icon>
 
-          </Button>
-        </Tooltip>
-      </HStack>
+            </Button>
+          </Tooltip>
+        </HStack>
+      )}
     </Flex>
   );
 };

--- a/src/components/MateriaMenu.js
+++ b/src/components/MateriaMenu.js
@@ -164,7 +164,7 @@ const Header = (props) => {
       </Flex>
 
       {getNode(displayedNode).categoria !== "CBC" && getNode(displayedNode).categoria !== "*CBC" && (
-        <HStack borderRadius={6} ml={2} border="2px solid white" height={"60%"}>
+        <HStack borderRadius={6} ml={2} border="2px solid white" height={"64%"}>
           <Tooltip closeOnClick hasArrow label="Planear Cuatri">
             <NumberInput
               css={{ margin: 0 }}
@@ -200,15 +200,25 @@ const Header = (props) => {
                   border="none"
                   color="white"
                   fontSize="large"
+                  fontWeight={"bold"}
+                  alignSelf={"center"}
                   height="50%"
-                  children={<strong>+</strong>}
+                  _hover={{
+                    color: "habilitadas.500"
+                  }}
+                  children="+"
                 />
                 <NumberDecrementStepper
                   border="none"
                   color="grey"
                   fontSize="large"
+                  fontWeight={"bold"}
+                  alignSelf={"center"}
                   height="50%"
-                  children={<strong>-</strong>}
+                  _hover={{
+                    color: "habilitadas.500"
+                  }}
+                  children="-"
                 />
               </NumberInputStepper>
             </NumberInput>
@@ -218,6 +228,7 @@ const Header = (props) => {
             <Button
               _hover={{
                 backgroundColor: "transparent",
+                color: "habilitadas.500"
               }}
               borderRadius="0"
               cursor="pointer"

--- a/src/components/MateriaMenu.js
+++ b/src/components/MateriaMenu.js
@@ -197,14 +197,14 @@ const Header = (props) => {
             <NumberInputStepper>
               <NumberIncrementStepper
                 border="none"
-                color="cursando.500"
+                color="white"
                 fontSize="large"
                 height="50%"
                 children={<strong>+</strong>}
               />
               <NumberDecrementStepper
                 border="none"
-                color="futuro.1000"
+                color="grey"
                 fontSize="large"
                 height="50%"
                 children={<strong>-</strong>}
@@ -223,7 +223,7 @@ const Header = (props) => {
             variant="link"
             borderLeft="2px solid white"
             fontSize="larger"
-            color="cursando.500"
+            color="white"
             onClick={() => cursando(displayedNode, undefined)}
           >
             <Icon boxSize={5} viewBox="0 0 24 24">

--- a/src/components/MateriaMenu.js
+++ b/src/components/MateriaMenu.js
@@ -42,42 +42,42 @@ const Header = (props) => {
         {getNode(displayedNode)?.nota > 0 ? (
           <Tooltip closeOnClick hasArrow label="Aprobar con Nota">
             <>
-            <NumberInput
-              css={{ margin: 0 }}
-              errorBorderColor="transparent"
-              borderColor="transparent"
-              inputMode="numeric"
-              onChange={(_, nota) => {
-                aprobar(displayedNode, nota);
-              }}
-              value={getNode(displayedNode)?.nota}
-              min={4}
-              max={10}
-              maxW={16}
-            >
-              <NumberInputField
-                _hover={{
-                  borderColor: "transparent",
+              <NumberInput
+                css={{ margin: 0 }}
+                errorBorderColor="transparent"
+                borderColor="transparent"
+                inputMode="numeric"
+                onChange={(_, nota) => {
+                  aprobar(displayedNode, nota);
                 }}
-                _focus={{
-                  borderColor: "transparent",
-                }}
-                color="white"
-                fontWeight="bold"
-              />
-              <NumberInputStepper mr={1}>
-                <NumberIncrementStepper
-                  border="none"
-                  fontSize="small"
-                  color="green.500"
+                value={getNode(displayedNode)?.nota}
+                min={4}
+                max={10}
+                maxW={16}
+              >
+                <NumberInputField
+                  _hover={{
+                    borderColor: "transparent",
+                  }}
+                  _focus={{
+                    borderColor: "transparent",
+                  }}
+                  color="white"
+                  fontWeight="bold"
                 />
-                <NumberDecrementStepper
-                  border="none"
-                  fontSize="small"
-                  color="red.500"
-                />
-              </NumberInputStepper>
-            </NumberInput>
+                <NumberInputStepper mr={1}>
+                  <NumberIncrementStepper
+                    border="none"
+                    fontSize="small"
+                    color="green.500"
+                  />
+                  <NumberDecrementStepper
+                    border="none"
+                    fontSize="small"
+                    color="red.500"
+                  />
+                </NumberInputStepper>
+              </NumberInput>
               <Tooltip closeOnClick hasArrow label="Aprobar por Equivalencia">
                 <Button
                   alignSelf="center"
@@ -145,65 +145,65 @@ const Header = (props) => {
         </Tooltip>
       </Flex>
 
-        <HStack spacing={4}>
-          <HStack borderRadius={6} ml={1} border="2px solid white">
-            <Tooltip closeOnClick hasArrow label="Cursando Actualmente">
-              <Button
-                _hover={{
-                  backgroundColor: "transparent",
-                }}
-                borderRadius="0"
-                cursor="pointer"
-                variant="link"
-                borderRight="2px solid white"
-                fontSize="larger"
-                color="cursando.500"
-                onClick={() => cursando(displayedNode, 0)}
-              >
-                <strong>C</strong>
-              </Button>
-            </Tooltip>
+      <HStack spacing={4}>
+        <HStack borderRadius={6} ml={1} border="2px solid white">
+          <Tooltip closeOnClick hasArrow label="Cursando Actualmente">
+            <Button
+              _hover={{
+                backgroundColor: "transparent",
+              }}
+              borderRadius="0"
+              cursor="pointer"
+              variant="link"
+              borderRight="2px solid white"
+              fontSize="larger"
+              color="cursando.500"
+              onClick={() => cursando(displayedNode, 0)}
+            >
+              <strong>C</strong>
+            </Button>
+          </Tooltip>
 
-            <Tooltip closeOnClick hasArrow label="A cursar en N cuatris">
-              <NumberInput
-                css={{ margin: 0 }}
-                errorBorderColor="white.500"
-                borderColor="transparent"
-                onChange={(_, cuatri) => {
-                  cursando(displayedNode, cuatri);
+          <Tooltip closeOnClick hasArrow label="A cursar en N cuatris">
+            <NumberInput
+              css={{ margin: 0 }}
+              errorBorderColor="white.500"
+              borderColor="transparent"
+              onChange={(_, cuatri) => {
+                cursando(displayedNode, cuatri);
+              }}
+              value={formatCuatri(getNode(displayedNode)?.cuatri)}
+              min={0}
+              max={10}
+            >
+              <NumberInputField
+                _hover={{
+                  borderColor: "transparent",
                 }}
-                value={formatCuatri(getNode(displayedNode)?.cuatri)}
-                min={0}
-                max={10}
-              >
-                <NumberInputField
-                  _hover={{
-                    borderColor: "transparent",
-                  }}
-                  _focus={{
-                    borderColor: "transparent",
-                  }}
-                  p={0}
-                  w="6ch"
-                  color="white"
-                  fontWeight="bold"
+                _focus={{
+                  borderColor: "transparent",
+                }}
+                p={0}
+                w="6ch"
+                color="white"
+                fontWeight="bold"
+              />
+              <NumberInputStepper>
+                <NumberIncrementStepper
+                  border="none"
+                  color="cursando.500"
+                  fontSize="large"
+                  height="50%"
+                  children={<strong>+</strong>}
                 />
-                <NumberInputStepper>
-                  <NumberIncrementStepper
-                    border="none"
-                    color="cursando.500"
-                    fontSize="large"
-                    height="50%"
-                    children={<strong>+</strong>}
-                  />
-                  <NumberDecrementStepper
-                    border="none"
-                    color="futuro.1000"
-                    fontSize="large"
-                    height="50%"
-                    children={<strong>-</strong>}
-                  />
-                </NumberInputStepper>
+                <NumberDecrementStepper
+                  border="none"
+                  color="futuro.1000"
+                  fontSize="large"
+                  height="50%"
+                  children={<strong>-</strong>}
+                />
+              </NumberInputStepper>
             </NumberInput>
           </Tooltip>
         </HStack>

--- a/src/components/MateriaMenu.js
+++ b/src/components/MateriaMenu.js
@@ -29,10 +29,12 @@ const Header = (props) => {
     (event) => {
       const node = getNode(displayedNode)
       if (event.keyCode === 37) { // <-
+        if (getNode(displayedNode).categoria === "CBC" || getNode(displayedNode).categoria === "*CBC") return
         const prevCuatri = node.cuatrimestre ? node.cuatrimestre - 0.5 : getCurrentCuatri();
         cursando(displayedNode, prevCuatri);
       }
       if (event.keyCode === 39) { // ->
+        if (getNode(displayedNode).categoria === "CBC" || getNode(displayedNode).categoria === "*CBC") return
         const nextCuatri = node.cuatrimestre ? node.cuatrimestre + 0.5 : getCurrentCuatri();
         cursando(displayedNode, nextCuatri);
       }

--- a/src/components/MateriaMenu.js
+++ b/src/components/MateriaMenu.js
@@ -1,15 +1,11 @@
 import {
-  ArrowLeftIcon,
-  ArrowRightIcon,
   CheckIcon,
   CloseIcon,
 } from "@chakra-ui/icons";
 import {
   Button,
-  Collapse,
   Flex,
   HStack,
-  IconButton,
   NumberDecrementStepper,
   NumberIncrementStepper,
   NumberInput,
@@ -27,9 +23,6 @@ const Header = (props) => {
   const { displayedNode } = props;
   const { getNode, aprobar, desaprobar, cursando } =
     React.useContext(GraphContext);
-  const [moreOptionsOpen, setMoreOptionsOpen] = React.useState(
-    getNode(displayedNode)?.cuatri > -1
-  );
 
   const formatCuatri = (cuatri) => {
     if (cuatri === -1) return "/";
@@ -48,6 +41,7 @@ const Header = (props) => {
       <Flex borderRadius={6} border="2px solid white" p={1} alignItems="center">
         {getNode(displayedNode)?.nota > 0 ? (
           <Tooltip closeOnClick hasArrow label="Aprobar con Nota">
+            <>
             <NumberInput
               css={{ margin: 0 }}
               errorBorderColor="transparent"
@@ -84,6 +78,23 @@ const Header = (props) => {
                 />
               </NumberInputStepper>
             </NumberInput>
+              <Tooltip closeOnClick hasArrow label="Aprobar por Equivalencia">
+                <Button
+                  alignSelf="center"
+                  _hover={{
+                    backgroundColor: "transparent",
+                  }}
+                  variant="link"
+                  fontSize="small"
+                  color="aprobadas.400"
+                  minW={0}
+                  mr={2}
+                  onClick={() => aprobar(displayedNode, 0)}
+                >
+                  <strong>E</strong>
+                </Button>
+              </Tooltip>
+            </>
           </Tooltip>
         ) : (
           <Tooltip closeOnClick hasArrow label="Aprobar">
@@ -134,21 +145,6 @@ const Header = (props) => {
         </Tooltip>
       </Flex>
 
-      <Tooltip closeOnClick hasArrow label="Más Opciones">
-        <IconButton
-          mx={4}
-          border="2px"
-          onClick={() => setMoreOptionsOpen(!moreOptionsOpen)}
-          variant="outline"
-          color="white"
-          colorScheme="whiteAlpha"
-          fontSize="20px"
-          transform="rotate(90deg)"
-          icon={moreOptionsOpen ? <ArrowRightIcon /> : <ArrowLeftIcon />}
-        />
-      </Tooltip>
-
-      <Collapse in={moreOptionsOpen} direction="left">
         <HStack spacing={4}>
           <HStack borderRadius={6} ml={1} border="2px solid white">
             <Tooltip closeOnClick hasArrow label="Cursando Actualmente">
@@ -208,27 +204,10 @@ const Header = (props) => {
                     children={<strong>-</strong>}
                   />
                 </NumberInputStepper>
-              </NumberInput>
-            </Tooltip>
-          </HStack>
-          <Tooltip closeOnClick hasArrow label="Aprobar por Equivalencia">
-            <Button
-              p={2}
-              _hover={{
-                backgroundColor: "transparent",
-              }}
-              cursor="pointer"
-              variant="link"
-              border="2px solid white"
-              fontSize="larger"
-              color="aprobadas.400"
-              onClick={() => aprobar(displayedNode, 0)}
-            >
-              <strong>E</strong>
-            </Button>
+            </NumberInput>
           </Tooltip>
         </HStack>
-      </Collapse>
+      </HStack>
     </Flex>
   );
 };

--- a/src/components/MateriaMenu.js
+++ b/src/components/MateriaMenu.js
@@ -1,6 +1,7 @@
 import {
   CheckIcon,
   CloseIcon,
+  Icon,
 } from "@chakra-ui/icons";
 import {
   Button,
@@ -24,10 +25,27 @@ const Header = (props) => {
   const { getNode, aprobar, desaprobar, cursando } =
     React.useContext(GraphContext);
 
-  const formatCuatri = (cuatri) => {
-    if (cuatri === -1) return "/";
-    return `+` + cuatri;
+  const getCurrentCuatri = () => {
+    const today = new Date();
+    let cuatri = today.getFullYear();
+    const month = today.getMonth();
+    if (month > 6) cuatri = cuatri + 0.5;
+    return cuatri;
+  }
+
+  const formatCuatri = (cuatristr) => {
+    if (!cuatristr) return "/";
+    const cuatri = parseFloat(cuatristr)
+    if (cuatri % 1 === 0) return `${cuatri}C1`;
+    return `${Math.floor(cuatri)}C2`;
   };
+
+  const parseCuatri = (cuatristr) => {
+    if (cuatristr === "/") return undefined;
+    const [y, c] = cuatristr.split("C");
+    if (c === "1") return y;
+    return y + 0.5;
+  }
 
   return (
     <Flex height="4em" alignItems="center" justifyContent="space-around">
@@ -38,7 +56,7 @@ const Header = (props) => {
         </StatHelpText>
       </Stat>
 
-      <Flex borderRadius={6} border="2px solid white" p={1} alignItems="center">
+      <Flex borderRadius={6} border="2px solid white" p={1} alignItems="center" height={"70%"}>
         {getNode(displayedNode)?.nota > 0 ? (
           <Tooltip closeOnClick hasArrow label="Aprobar con Nota">
             <>
@@ -145,68 +163,78 @@ const Header = (props) => {
         </Tooltip>
       </Flex>
 
-      <HStack spacing={4}>
-        <HStack borderRadius={6} ml={1} border="2px solid white">
-          <Tooltip closeOnClick hasArrow label="Cursando Actualmente">
-            <Button
+      <HStack borderRadius={6} ml={2} border="2px solid white" height={"60%"}>
+        <Tooltip closeOnClick hasArrow label="Planear Cuatri">
+          <NumberInput
+            css={{ margin: 0 }}
+            errorBorderColor="white.500"
+            borderColor="transparent"
+            onChange={(_, cuatri) => {
+              cursando(displayedNode, cuatri);
+            }}
+            value={getNode(displayedNode)?.cuatrimestre}
+            format={formatCuatri}
+            parse={parseCuatri}
+            step={0.5}
+            precision={1}
+            key={getNode(displayedNode)?.cuatrimestre}
+            min={getNode(displayedNode)?.cuatrimestre ? 1986 : getCurrentCuatri()}
+            max={2050}
+          >
+            <NumberInputField
               _hover={{
-                backgroundColor: "transparent",
+                borderColor: "transparent",
               }}
-              borderRadius="0"
-              cursor="pointer"
-              variant="link"
-              borderRight="2px solid white"
-              fontSize="larger"
-              color="cursando.500"
-              onClick={() => cursando(displayedNode, 0)}
-            >
-              <strong>C</strong>
-            </Button>
-          </Tooltip>
-
-          <Tooltip closeOnClick hasArrow label="A cursar en N cuatris">
-            <NumberInput
-              css={{ margin: 0 }}
-              errorBorderColor="white.500"
-              borderColor="transparent"
-              onChange={(_, cuatri) => {
-                cursando(displayedNode, cuatri);
+              _focus={{
+                borderColor: "transparent",
               }}
-              value={formatCuatri(getNode(displayedNode)?.cuatri)}
-              min={0}
-              max={10}
-            >
-              <NumberInputField
-                _hover={{
-                  borderColor: "transparent",
-                }}
-                _focus={{
-                  borderColor: "transparent",
-                }}
-                p={0}
-                w="6ch"
-                color="white"
-                fontWeight="bold"
+              p={0}
+              ml={2}
+              w="10ch"
+              color="white"
+              fontWeight="bold"
+            />
+            <NumberInputStepper>
+              <NumberIncrementStepper
+                border="none"
+                color="cursando.500"
+                fontSize="large"
+                height="50%"
+                children={<strong>+</strong>}
               />
-              <NumberInputStepper>
-                <NumberIncrementStepper
-                  border="none"
-                  color="cursando.500"
-                  fontSize="large"
-                  height="50%"
-                  children={<strong>+</strong>}
-                />
-                <NumberDecrementStepper
-                  border="none"
-                  color="futuro.1000"
-                  fontSize="large"
-                  height="50%"
-                  children={<strong>-</strong>}
-                />
-              </NumberInputStepper>
-            </NumberInput>
-          </Tooltip>
-        </HStack>
+              <NumberDecrementStepper
+                border="none"
+                color="futuro.1000"
+                fontSize="large"
+                height="50%"
+                children={<strong>-</strong>}
+              />
+            </NumberInputStepper>
+          </NumberInput>
+        </Tooltip>
+
+        <Tooltip closeOnClick hasArrow label="Limpiar Cuatri">
+          <Button
+            _hover={{
+              backgroundColor: "transparent",
+            }}
+            borderRadius="0"
+            cursor="pointer"
+            variant="link"
+            borderLeft="2px solid white"
+            fontSize="larger"
+            color="cursando.500"
+            onClick={() => cursando(displayedNode, undefined)}
+          >
+            <Icon boxSize={5} viewBox="0 0 24 24">
+              <path
+                fill="currentColor"
+                d="M12.2071 2.29289C12.5976 2.68342 12.5976 3.31658 12.2071 3.70711L10.9142 5H12.5C17.1523 5 21 8.84772 21 13.5C21 18.1523 17.1523 22 12.5 22C7.84772 22 4 18.1523 4 13.5C4 12.9477 4.44772 12.5 5 12.5C5.55228 12.5 6 12.9477 6 13.5C6 17.0477 8.95228 20 12.5 20C16.0477 20 19 17.0477 19 13.5C19 9.95228 16.0477 7 12.5 7H10.9142L12.2071 8.29289C12.5976 8.68342 12.5976 9.31658 12.2071 9.70711C11.8166 10.0976 11.1834 10.0976 10.7929 9.70711L7.79289 6.70711C7.40237 6.31658 7.40237 5.68342 7.79289 5.29289L10.7929 2.29289C11.1834 1.90237 11.8166 1.90237 12.2071 2.29289Z"
+              />
+            </Icon>
+
+          </Button>
+        </Tooltip>
       </HStack>
     </Flex>
   );

--- a/src/components/MateriaMenu.js
+++ b/src/components/MateriaMenu.js
@@ -25,6 +25,51 @@ const Header = (props) => {
   const { getNode, aprobar, desaprobar, cursando, getCurrentCuatri } =
     React.useContext(GraphContext);
 
+  const flechitas = React.useCallback(
+    (event) => {
+      const node = getNode(displayedNode)
+      if (event.keyCode === 37) { // <-
+        const prevCuatri = node.cuatrimestre ? node.cuatrimestre - 0.5 : getCurrentCuatri();
+        cursando(displayedNode, prevCuatri);
+      }
+      if (event.keyCode === 39) { // ->
+        const nextCuatri = node.cuatrimestre ? node.cuatrimestre + 0.5 : getCurrentCuatri();
+        cursando(displayedNode, nextCuatri);
+      }
+      if (event.keyCode === 38) { // ^
+        let nextNota = node.nota + 1;
+        if (node.nota === 0) nextNota = 4;
+        if (node.nota === 10) {
+          desaprobar(displayedNode)
+          return
+        };
+        aprobar(displayedNode, nextNota)
+      }
+      if (event.keyCode === 40) { // v
+        let prevNota = node.nota - 1;
+        if (node.nota === 4) prevNota = 0;
+        if (node.nota === -2) prevNota = 10;
+        if (node.nota === -1) {
+          desaprobar(displayedNode)
+          return
+        };
+        aprobar(displayedNode, prevNota)
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [displayedNode]
+  );
+
+  React.useEffect(() => {
+    document.addEventListener("keydown", flechitas, false);
+
+    return () => {
+      document.removeEventListener("keydown", flechitas, false);
+    };
+  }, [flechitas]);
+
+
+
   const formatCuatri = (cuatristr) => {
     if (!cuatristr) return "/";
     const cuatri = parseFloat(cuatristr)

--- a/src/constants.js
+++ b/src/constants.js
@@ -66,17 +66,6 @@ export const GRUPOS = {
     shape: "diamond",
     size: 45,
   },
-  Cursando: { color: COLORS.cursando[500] },
-  "A Cursar (1)": { color: COLORS.futuro[100] },
-  "A Cursar (2)": { color: COLORS.futuro[200] },
-  "A Cursar (3)": { color: COLORS.futuro[300] },
-  "A Cursar (4)": { color: COLORS.futuro[400] },
-  "A Cursar (5)": { color: COLORS.futuro[500] },
-  "A Cursar (6)": { color: COLORS.futuro[600] },
-  "A Cursar (7)": { color: COLORS.futuro[700] },
-  "A Cursar (8)": { color: COLORS.futuro[800] },
-  "A Cursar (9)": { color: COLORS.futuro[900] },
-  "A Cursar (10)": { color: COLORS.futuro[1000] },
   ...CARRERAS.filter((c) => c.orientaciones)
     .flatMap((c) => c.orientaciones)
     .reduce(function (map, obj) {

--- a/src/constants.js
+++ b/src/constants.js
@@ -104,8 +104,8 @@ export const GRAPHOPTIONS = {
   layout: {
     hierarchical: {
       enabled: true,
-      levelSeparation: 145,
-      treeSpacing: 0,
+      parentCentralization: false,
+      blockShifting: false,
       edgeMinimization: false,
       direction: "LR",
     },

--- a/src/data/sistemas-2014.js
+++ b/src/data/sistemas-2014.js
@@ -424,11 +424,11 @@ export const sistemas = [
     correlativas: "CBC",
     categoria: "Materias Electivas",
   },
-  // {
-  //   id: "95.61",
-  //   materia: "Trabajo Profesional de Licenciatura en Análisis de Sistemas",
-  //   creditos: 12,
-  //   correlativas: "95.24-95.59-95.60",
-  //   categoria: "Fin de Carrera (Obligatorio)",
-  // },
+  {
+    id: "95.61",
+    materia: "Trabajo Profesional de Licenciatura en Análisis de Sistemas",
+    creditos: 12,
+    correlativas: "95.24-95.59-95.60",
+    categoria: "Fin de Carrera (Obligatorio)",
+  },
 ];

--- a/src/data/sistemas-2014.js
+++ b/src/data/sistemas-2014.js
@@ -424,11 +424,11 @@ export const sistemas = [
     correlativas: "CBC",
     categoria: "Materias Electivas",
   },
-  {
-    id: "95.61",
-    materia: "Trabajo Profesional de Licenciatura en Análisis de Sistemas",
-    creditos: 12,
-    correlativas: "95.24-95.59-95.60",
-    categoria: "Fin de Carrera (Obligatorio)",
-  },
+  // {
+  //   id: "95.61",
+  //   materia: "Trabajo Profesional de Licenciatura en Análisis de Sistemas",
+  //   creditos: 12,
+  //   correlativas: "95.24-95.59-95.60",
+  //   categoria: "Fin de Carrera (Obligatorio)",
+  // },
 ];

--- a/src/theme.js
+++ b/src/theme.js
@@ -42,21 +42,6 @@ export const COLORS = {
     500: "#FDC802",
   },
   // https://color.adobe.com/create/color-wheel starting from #FF9999
-  cursando: {
-    500: "#eceef0",
-  },
-  futuro: {
-    100: "#d9dbdd",
-    200: "#cfd1d3",
-    300: "#c6c7c9",
-    400: "#bcbebf",
-    500: "#b3b4b5",
-    600: "#a9aaac",
-    700: "#9fa1a2",
-    800: "#969798",
-    900: "#8c8d8e",
-    1000: "#838485",
-  },
   orientacion1: {
     50: "#FFE5E5",
     500: "#FF9999",

--- a/src/useGraph.js
+++ b/src/useGraph.js
@@ -91,7 +91,6 @@ const useGraph = (loginHook) => {
                 node = node.cursando(m.cuatrimestre)
                 toUpdate.push(node);
               }
-              console.log(toUpdate)
             });
           }
           if (metadata.checkboxes)

--- a/src/useGraph.js
+++ b/src/useGraph.js
@@ -588,12 +588,11 @@ const useGraph = (loginHook) => {
 
       if (aprobadasSinCuatri.length) {
         toUpdate.push(...aprobadasSinCuatri.map((n) => {
-          n.level = n.originalLevel;
+          n.level = n.originalLevel ? n.originalLevel : n.level;
           return n;
         }))
         lastLevel = Math.max(...(toUpdate.map(n => n.level)))
       }
-
       toUpdate.push(...conCuatri.map((n) => {
         n.level = ((n.cuatrimestre - firstCuatri) / 0.5) + lastLevel + 1;
         return n;
@@ -609,7 +608,6 @@ const useGraph = (loginHook) => {
       })
       if (desaprobadasSinCuatri.length) {
         const firstOffset = Math.min(...desaprobadasSinCuatri.map(n => n.originalLevel))
-        console.log(firstOffset)
         toUpdate.push(...desaprobadasSinCuatri.map((n) => {
           const offset = isFinite(firstOffset) && n.originalLevel ? n.originalLevel - firstOffset : 0
           n.level = lastLevel + offset + 1;

--- a/src/useGraph.js
+++ b/src/useGraph.js
@@ -504,10 +504,6 @@ const useGraph = (loginHook) => {
       const groupOrder = [
         "Aprobadas",
         "En Final",
-        "Cursando",
-        ...Array(10)
-          .fill()
-          .map((_, i) => `A Cursar (${i + 1})`),
         "Habilitadas",
         "Materias Electivas",
       ];
@@ -548,7 +544,7 @@ const useGraph = (loginHook) => {
       .get({
         filter: (n) =>
           n.categoria === "Materias Electivas" &&
-          (n.aprobada || n.nota === -1 || n.cuatri >= 0),
+          (n.aprobada || n.nota === -1 || n.cuatrimestre),
         fields: ["id"],
       })
       .map((n) => {
@@ -567,7 +563,7 @@ const useGraph = (loginHook) => {
           n.categoria !== "Materias Electivas" &&
           n.categoria !== "Fin de Carrera (Obligatorio)" &&
           n.categoria !== "Fin de Carrera" &&
-          (n.aprobada || n.nota === -1 || n.cuatri >= 0),
+          (n.aprobada || n.nota === -1 || n.cuatrimestre),
         fields: ["id"],
       })
       .map((n) => {

--- a/src/useGraph.js
+++ b/src/useGraph.js
@@ -674,7 +674,7 @@ const useGraph = (loginHook) => {
     if (!ultimaAprobada) return
 
     const toUpdate = []
-    toUpdate.push(getNode(ultimaAprobada.id).cursando(getCurrentCuatri()))
+    toUpdate.push(getNode(ultimaAprobada.id).cursando(getCurrentCuatri() - 1))
 
     const allOtherAprobadas = nodes.get({
       filter: (n) =>
@@ -686,7 +686,7 @@ const useGraph = (loginHook) => {
         n.id !== ultimaAprobada.id
     })
     toUpdate.push(...allOtherAprobadas.map((n) => {
-      const cuatri = getCurrentCuatri() + ((n.level - ultimaAprobada.level) * 0.5)
+      const cuatri = getCurrentCuatri() - 1 + ((n.level - ultimaAprobada.level) * 0.5)
       return getNode(n.id).cursando(cuatri)
     }))
 

--- a/src/useGraph.js
+++ b/src/useGraph.js
@@ -517,6 +517,8 @@ const useGraph = (loginHook) => {
         .get({
           filter: (n) =>
             n.categoria !== "Materias Electivas" &&
+            n.categoria !== "*CBC" &&
+            n.categoria !== "CBC" &&
             n.categoria !== "Fin de Carrera" &&
             n.categoria !== "Fin de Carrera (Obligatorio)",
           fields: ["level"],
@@ -534,6 +536,7 @@ const useGraph = (loginHook) => {
         counter = 0;
         addLevel += 1;
       }
+      node.originalLevel = lastLevel + addLevel;
       node.level = lastLevel + addLevel;
     });
     nodes.update(electivas);

--- a/src/useGraph.js
+++ b/src/useGraph.js
@@ -625,6 +625,34 @@ const useGraph = (loginHook) => {
         !n.cuatrimestre
     })
     toUpdate.push(...balanceShownElectivas(electivas, lastLevel));
+
+    lastLevel = Math.max(...toUpdate.map(n => n.level))
+    if (!isFinite(lastLevel)) {
+      lastLevel = Math.max(
+        ...nodes
+          .get({
+            filter: (n) =>
+              !n.hidden &&
+              n.categoria !== "Fin de Carrera" &&
+              n.categoria !== "Fin de Carrera (Obligatorio)",
+            fields: ["level"],
+            type: { level: "number" },
+          })
+          .map((n) => n.level)
+      );
+    }
+
+    const findecarrera = nodes.get({
+      filter: (n) =>
+        (n.categoria === "Fin de Carrera" || n.categoria === "Fin de Carrera (Obligatorio)") &&
+        !n.hidden &&
+        !n.cuatrimestre
+    })
+    toUpdate.push(...findecarrera.map((n) => {
+      n.level = lastLevel + 1;
+      return n
+    }))
+
     nodes.update(toUpdate)
 
     return

--- a/src/useGraph.js
+++ b/src/useGraph.js
@@ -79,8 +79,9 @@ const useGraph = (loginHook) => {
               if (!getNode(m.id)) return;
               if (m.nota >= -1) {
                 toUpdate.push(getNode(m.id).aprobar(m.nota));
-              } else if (m.cuatri >= 0) {
-                toUpdate.push(getNode(m.id).cursando(m.cuatri));
+              }
+              if (m.cuatrimestre) {
+                toUpdate.push(getNode(m.id).cursando(m.cuatrimestre));
               }
             });
           }
@@ -242,8 +243,8 @@ const useGraph = (loginHook) => {
     actualizar();
   };
 
-  const cursando = (id, cuatri) => {
-    nodes.update(getNode(id).cursando(cuatri));
+  const cursando = (id, cuatrimestre) => {
+    nodes.update(getNode(id).cursando(cuatrimestre));
     actualizar();
   };
 

--- a/src/useGraph.js
+++ b/src/useGraph.js
@@ -202,8 +202,7 @@ const useGraph = (loginHook) => {
         group = graph.nodes
           .filter((n) =>
             n.categoria === categoria &&
-            n.group !== categoria &&
-            n.group !== "Habilitadas")
+            (n.cuatrimestre || n.nota >= -1))
           .map((n) => {
             const node = getNode(n.id);
             node.hidden = false;

--- a/src/useLogin.js
+++ b/src/useLogin.js
@@ -90,8 +90,8 @@ const useLogin = () => {
     const carreraid = user.carrera.id;
     const map = {
       materias: nodes.get({
-        filter: (n) => n.aprobada || n.nota === -1 || n.cuatri >= 0,
-        fields: ["id", "nota", "cuatri"],
+        filter: (n) => n.aprobada || n.nota === -1 || n.cuatrimestre,
+        fields: ["id", "nota", "cuatrimestre"],
       }),
     };
     if (checkboxes)


### PR DESCRIPTION
La idea de este PR es reemplazar todo el código del atributo `.cuatri` de cada nodo por un nuevo atributo `.cuatrimestre`, que en vez de ser offsets (+1, +2, etc) sea numeros absolutos (2022C1, 2022C2, etc), y que cada uno de esos cuatrimestres corresponda a una columna del mapa

- [x] frontend
- [x] backend


Closes #120 