### PR TITLE
Remplazar materia del CBC Quimica 5 por Pensamiento Computacional 90

### DIFF
--- a/src/data/agrimensura-2006.json
+++ b/src/data/agrimensura-2006.json
@@ -28,8 +28,8 @@
     "level": -1
   },
   {
-    "id": "CBC90",
-    "materia": "Pensamiento Computacional",
+    "id": "CBC5",
+    "materia": "Química / Pensamiento Computacional",
     "creditos": 6,
     "categoria": "*CBC",
     "level": -1
@@ -47,7 +47,7 @@
     "creditos": 0,
     "categoria": "CBC",
     "level": 0,
-    "correlativas": "CBC28-CBC27-CBC3-CBC90-CBC24-CBC40"
+    "correlativas": "CBC28-CBC27-CBC3-CBC5-CBC24-CBC40"
   },
   {
     "id": "62.01",

--- a/src/data/agrimensura-2006.json
+++ b/src/data/agrimensura-2006.json
@@ -1,1 +1,416 @@
-[{ "id": "CBC28", "materia": "Análisis Matemático", "creditos": 9, "categoria": "*CBC", "level": -2 }, { "id": "CBC27", "materia": "Álgebra", "creditos": 9, "categoria": "*CBC", "level": -2 }, { "id": "CBC24", "materia": "Introducción al Conocimiento de la Sociedad y el Estado", "creditos": 4, "categoria": "*CBC", "level": -2 }, { "id": "CBC3", "materia": "Física", "creditos": 6, "categoria": "*CBC", "level": -1 }, { "id": "CBC5", "materia": "Química", "creditos": 6, "categoria": "*CBC", "level": -1 }, { "id": "CBC40", "materia": "Introducción al Pensamiento Científico", "creditos": 4, "categoria": "*CBC", "level": -1 }, { "id": "CBC", "materia": "Ciclo Básico Común", "creditos": 0, "categoria": "CBC", "level": 0, "correlativas": "CBC28-CBC27-CBC3-CBC5-CBC24-CBC40" }, { "id": "62.01", "materia": "Física I A", "creditos": 8, "correlativas": "CBC", "categoria": "Materias Obligatorias", "level": 1 }, { "id": "61.03", "materia": "Análisis Matemático II A", "creditos": 8, "correlativas": "CBC", "categoria": "Materias Obligatorias", "level": 1 }, { "id": "70.02", "materia": "Geometría Descriptiva", "creditos": 4, "correlativas": "CBC", "categoria": "Materias Obligatorias", "level": 1 }, { "id": "75.01", "materia": "Computación", "creditos": 4, "correlativas": "CBC", "categoria": "Materias Obligatorias", "level": 1 }, { "id": "62.03", "materia": "Física II A", "creditos": 8, "correlativas": "61.03-62.01", "categoria": "Materias Obligatorias", "level": 2 }, { "id": "70.04", "materia": "Dibujo Topográfico", "creditos": 4, "correlativas": "CBC", "categoria": "Materias Obligatorias", "level": 2 }, { "id": "78.01", "materia": "Idioma Ingles", "creditos": 4, "correlativas": "CBC", "categoria": "Materias Obligatorias", "level": 2 }, { "id": "61.22", "materia": "Álgebra II C", "creditos": 8, "correlativas": "CBC", "categoria": "Materias Obligatorias", "level": 2 }, { "id": "70.06", "materia": "Geografía Física y Geología", "creditos": 4, "correlativas": "62.01", "categoria": "Materias Obligatorias", "level": 3 }, { "id": "71.23", "materia": "Economía", "creditos": 4, "correlativas": "61.03", "categoria": "Materias Obligatorias", "level": 3 }, { "id": "61.06", "materia": "Probabilidad y Estadística A", "creditos": 4, "correlativas": "61.03", "categoria": "Materias Obligatorias", "level": 3 }, { "id": "70.08", "materia": "Topografía I", "creditos": 6, "correlativas": "70.02", "categoria": "Materias Obligatorias", "level": 3 }, { "id": "70.12", "materia": "Geodesia I", "creditos": 4, "correlativas": "61.03-70.08", "categoria": "Materias Obligatorias", "level": 3 }, { "id": "70.33", "materia": "Elementos de Construcción", "creditos": 4, "correlativas": "70.08", "categoria": "Materias Obligatorias", "level": 4 }, { "id": "70.15", "materia": "Cartografía", "creditos": 4, "correlativas": "70.08", "categoria": "Materias Obligatorias", "level": 4 }, { "id": "70.07", "materia": "Calculo De Compensación", "creditos": 4, "correlativas": "61.06-70.08", "categoria": "Materias Obligatorias", "level": 4 }, { "id": "70.09", "materia": "Topografía II", "creditos": 6, "correlativas": "70.08-70.04", "categoria": "Materias Obligatorias", "level": 4 }, { "id": "70.13", "materia": "Geodesia II", "creditos": 4, "correlativas": "70.12", "categoria": "Materias Obligatorias", "level": 4 }, { "id": "68.06", "materia": "Transporte A", "creditos": 8, "correlativas": "70.09", "categoria": "Materias Obligatorias", "level": 5 }, { "id": "70.14", "materia": "Fotogrametría I", "creditos": 4, "correlativas": "70.09", "categoria": "Materias Obligatorias", "level": 5 }, { "id": "71.02", "materia": "Agrimensura Legal I", "creditos": 4, "correlativas": "70.08", "categoria": "Materias Obligatorias", "level": 5 }, { "id": "70.34", "materia": "Topografía III", "creditos": 8, "correlativas": "70.07-70.09-70.12-70.15", "categoria": "Materias Obligatorias", "level": 5 }, { "id": "70.17", "materia": "Geodesia III", "creditos": 4, "correlativas": "62.03-70.07-70.13", "categoria": "Materias Obligatorias", "level": 6 }, { "id": "70.16", "materia": "Fotogrametría II", "creditos": 4, "correlativas": "70.14-70.07", "categoria": "Materias Obligatorias", "level": 6 }, { "id": "70.36", "materia": "Sistemas Cartográficos y Teledetección", "creditos": 4, "correlativas": "61.06-70.14-70.15", "categoria": "Materias Obligatorias", "level": 6 }, { "id": "71.24", "materia": "Agrimensura Legal II", "creditos": 4, "correlativas": "71.02", "categoria": "Materias Obligatorias", "level": 6 }, { "id": "70.35", "materia": "Topografía IV", "creditos": 8, "correlativas": "70.34-70.13", "categoria": "Materias Obligatorias", "level": 6 }, { "id": "70.32", "materia": "Sistemas de Información Geográfica", "creditos": 4, "correlativas": "70.04-70.15-70.36", "categoria": "Materias Obligatorias", "level": 7 }, { "id": "70.31", "materia": "Información Rural", "creditos": 4, "correlativas": "71.23-71.24-70.36", "categoria": "Materias Obligatorias", "level": 7 }, { "id": "70.27", "materia": "Catastro", "creditos": 4, "correlativas": "70.16-71.23-71.24", "categoria": "Materias Obligatorias", "level": 7 }, { "id": "71.30", "materia": "Agrimensura Legal III", "creditos": 4, "correlativas": "71.24", "categoria": "Materias Obligatorias", "level": 7 }, { "id": "70.37", "materia": "Levantamiento y Práctica Profesional I", "creditos": 6, "correlativas": "70.35-71.24", "categoria": "Materias Obligatorias", "level": 7 }, { "id": "70.39", "materia": "Valuaciones", "creditos": 4, "correlativas": "71.23-70.27-70.33", "categoria": "Materias Obligatorias", "level": 8 }, { "id": "70.38", "materia": "Levantamiento y Práctica Profesional II", "creditos": 6, "correlativas": "70.33-70.37", "categoria": "Materias Obligatorias", "level": 8 }, { "id": "71.52", "materia": "Agrimensura Legal IV", "creditos": 6, "correlativas": "71.30", "categoria": "Materias Obligatorias", "level": 8 }, { "id": "70.24", "materia": "Levantamientos Hidrográficos", "creditos": 4, "correlativas": "70.09", "categoria": "Materias Electivas" }, { "id": "70.26", "materia": "Hidráulica Agrícola y Saneamiento", "creditos": 4, "correlativas": "70.09", "categoria": "Materias Electivas" }, { "id": "77.02", "materia": "Introducción a la Ingeniería Ambiental", "creditos": 4, "requiere": 100, "categoria": "Materias Electivas" }, { "id": "68.11", "materia": "Ordenamiento Rural y Urbano", "creditos": 4, "correlativas": "68.06-70.27", "categoria": "Materias Electivas" }, { "id": "70.40", "materia": "Geología Aplicada", "creditos": 4, "correlativas": "62.03-70.06", "categoria": "Materias Electivas" }, { "id": "70.41", "materia": "Oceanografía Física", "creditos": 4, "correlativas": "61.03-62.03", "categoria": "Materias Electivas" }, { "id": "70.42", "materia": "Sistemas de Información Geográfica II", "creditos": 4, "correlativas": "70.32", "categoria": "Materias Electivas" }, { "id": "70.43", "materia": "Topografía De Obra", "creditos": 4, "correlativas": "70.12-70.09", "categoria": "Materias Electivas" }, { "id": "70.44", "materia": "Dibujo Topográfico II", "creditos": 4, "correlativas": "70.04", "categoria": "Materias Electivas" }, { "id": "78.xx", "materia": "Idioma", "creditos": 4, "correlativas": "CBC", "categoria": "Materias Electivas" }, { "id": "70.00", "materia": "Tesis de Ingeniería en Agrimensura", "creditos": 18, "requiere": 140, "categoria": "Fin de Carrera" }, { "id": "70.99", "materia": "Trabajo Profesional de la Ingeniería en Agrimensura", "creditos": 12, "requiere": 140, "categoria": "Fin de Carrera" }]
+[
+  {
+    "id": "CBC28",
+    "materia": "Análisis Matemático",
+    "creditos": 9,
+    "categoria": "*CBC",
+    "level": -2
+  },
+  {
+    "id": "CBC27",
+    "materia": "Álgebra",
+    "creditos": 9,
+    "categoria": "*CBC",
+    "level": -2
+  },
+  {
+    "id": "CBC24",
+    "materia": "Introducción al Conocimiento de la Sociedad y el Estado",
+    "creditos": 4,
+    "categoria": "*CBC",
+    "level": -2
+  },
+  {
+    "id": "CBC3",
+    "materia": "Física",
+    "creditos": 6,
+    "categoria": "*CBC",
+    "level": -1
+  },
+  {
+    "id": "CBC90",
+    "materia": "Pensamiento Computacional",
+    "creditos": 6,
+    "categoria": "*CBC",
+    "level": -1
+  },
+  {
+    "id": "CBC40",
+    "materia": "Introducción al Pensamiento Científico",
+    "creditos": 4,
+    "categoria": "*CBC",
+    "level": -1
+  },
+  {
+    "id": "CBC",
+    "materia": "Ciclo Básico Común",
+    "creditos": 0,
+    "categoria": "CBC",
+    "level": 0,
+    "correlativas": "CBC28-CBC27-CBC3-CBC90-CBC24-CBC40"
+  },
+  {
+    "id": "62.01",
+    "materia": "Física I A",
+    "creditos": 8,
+    "correlativas": "CBC",
+    "categoria": "Materias Obligatorias",
+    "level": 1
+  },
+  {
+    "id": "61.03",
+    "materia": "Análisis Matemático II A",
+    "creditos": 8,
+    "correlativas": "CBC",
+    "categoria": "Materias Obligatorias",
+    "level": 1
+  },
+  {
+    "id": "70.02",
+    "materia": "Geometría Descriptiva",
+    "creditos": 4,
+    "correlativas": "CBC",
+    "categoria": "Materias Obligatorias",
+    "level": 1
+  },
+  {
+    "id": "75.01",
+    "materia": "Computación",
+    "creditos": 4,
+    "correlativas": "CBC",
+    "categoria": "Materias Obligatorias",
+    "level": 1
+  },
+  {
+    "id": "62.03",
+    "materia": "Física II A",
+    "creditos": 8,
+    "correlativas": "61.03-62.01",
+    "categoria": "Materias Obligatorias",
+    "level": 2
+  },
+  {
+    "id": "70.04",
+    "materia": "Dibujo Topográfico",
+    "creditos": 4,
+    "correlativas": "CBC",
+    "categoria": "Materias Obligatorias",
+    "level": 2
+  },
+  {
+    "id": "78.01",
+    "materia": "Idioma Ingles",
+    "creditos": 4,
+    "correlativas": "CBC",
+    "categoria": "Materias Obligatorias",
+    "level": 2
+  },
+  {
+    "id": "61.22",
+    "materia": "Álgebra II C",
+    "creditos": 8,
+    "correlativas": "CBC",
+    "categoria": "Materias Obligatorias",
+    "level": 2
+  },
+  {
+    "id": "70.06",
+    "materia": "Geografía Física y Geología",
+    "creditos": 4,
+    "correlativas": "62.01",
+    "categoria": "Materias Obligatorias",
+    "level": 3
+  },
+  {
+    "id": "71.23",
+    "materia": "Economía",
+    "creditos": 4,
+    "correlativas": "61.03",
+    "categoria": "Materias Obligatorias",
+    "level": 3
+  },
+  {
+    "id": "61.06",
+    "materia": "Probabilidad y Estadística A",
+    "creditos": 4,
+    "correlativas": "61.03",
+    "categoria": "Materias Obligatorias",
+    "level": 3
+  },
+  {
+    "id": "70.08",
+    "materia": "Topografía I",
+    "creditos": 6,
+    "correlativas": "70.02",
+    "categoria": "Materias Obligatorias",
+    "level": 3
+  },
+  {
+    "id": "70.12",
+    "materia": "Geodesia I",
+    "creditos": 4,
+    "correlativas": "61.03-70.08",
+    "categoria": "Materias Obligatorias",
+    "level": 3
+  },
+  {
+    "id": "70.33",
+    "materia": "Elementos de Construcción",
+    "creditos": 4,
+    "correlativas": "70.08",
+    "categoria": "Materias Obligatorias",
+    "level": 4
+  },
+  {
+    "id": "70.15",
+    "materia": "Cartografía",
+    "creditos": 4,
+    "correlativas": "70.08",
+    "categoria": "Materias Obligatorias",
+    "level": 4
+  },
+  {
+    "id": "70.07",
+    "materia": "Calculo De Compensación",
+    "creditos": 4,
+    "correlativas": "61.06-70.08",
+    "categoria": "Materias Obligatorias",
+    "level": 4
+  },
+  {
+    "id": "70.09",
+    "materia": "Topografía II",
+    "creditos": 6,
+    "correlativas": "70.08-70.04",
+    "categoria": "Materias Obligatorias",
+    "level": 4
+  },
+  {
+    "id": "70.13",
+    "materia": "Geodesia II",
+    "creditos": 4,
+    "correlativas": "70.12",
+    "categoria": "Materias Obligatorias",
+    "level": 4
+  },
+  {
+    "id": "68.06",
+    "materia": "Transporte A",
+    "creditos": 8,
+    "correlativas": "70.09",
+    "categoria": "Materias Obligatorias",
+    "level": 5
+  },
+  {
+    "id": "70.14",
+    "materia": "Fotogrametría I",
+    "creditos": 4,
+    "correlativas": "70.09",
+    "categoria": "Materias Obligatorias",
+    "level": 5
+  },
+  {
+    "id": "71.02",
+    "materia": "Agrimensura Legal I",
+    "creditos": 4,
+    "correlativas": "70.08",
+    "categoria": "Materias Obligatorias",
+    "level": 5
+  },
+  {
+    "id": "70.34",
+    "materia": "Topografía III",
+    "creditos": 8,
+    "correlativas": "70.07-70.09-70.12-70.15",
+    "categoria": "Materias Obligatorias",
+    "level": 5
+  },
+  {
+    "id": "70.17",
+    "materia": "Geodesia III",
+    "creditos": 4,
+    "correlativas": "62.03-70.07-70.13",
+    "categoria": "Materias Obligatorias",
+    "level": 6
+  },
+  {
+    "id": "70.16",
+    "materia": "Fotogrametría II",
+    "creditos": 4,
+    "correlativas": "70.14-70.07",
+    "categoria": "Materias Obligatorias",
+    "level": 6
+  },
+  {
+    "id": "70.36",
+    "materia": "Sistemas Cartográficos y Teledetección",
+    "creditos": 4,
+    "correlativas": "61.06-70.14-70.15",
+    "categoria": "Materias Obligatorias",
+    "level": 6
+  },
+  {
+    "id": "71.24",
+    "materia": "Agrimensura Legal II",
+    "creditos": 4,
+    "correlativas": "71.02",
+    "categoria": "Materias Obligatorias",
+    "level": 6
+  },
+  {
+    "id": "70.35",
+    "materia": "Topografía IV",
+    "creditos": 8,
+    "correlativas": "70.34-70.13",
+    "categoria": "Materias Obligatorias",
+    "level": 6
+  },
+  {
+    "id": "70.32",
+    "materia": "Sistemas de Información Geográfica",
+    "creditos": 4,
+    "correlativas": "70.04-70.15-70.36",
+    "categoria": "Materias Obligatorias",
+    "level": 7
+  },
+  {
+    "id": "70.31",
+    "materia": "Información Rural",
+    "creditos": 4,
+    "correlativas": "71.23-71.24-70.36",
+    "categoria": "Materias Obligatorias",
+    "level": 7
+  },
+  {
+    "id": "70.27",
+    "materia": "Catastro",
+    "creditos": 4,
+    "correlativas": "70.16-71.23-71.24",
+    "categoria": "Materias Obligatorias",
+    "level": 7
+  },
+  {
+    "id": "71.30",
+    "materia": "Agrimensura Legal III",
+    "creditos": 4,
+    "correlativas": "71.24",
+    "categoria": "Materias Obligatorias",
+    "level": 7
+  },
+  {
+    "id": "70.37",
+    "materia": "Levantamiento y Práctica Profesional I",
+    "creditos": 6,
+    "correlativas": "70.35-71.24",
+    "categoria": "Materias Obligatorias",
+    "level": 7
+  },
+  {
+    "id": "70.39",
+    "materia": "Valuaciones",
+    "creditos": 4,
+    "correlativas": "71.23-70.27-70.33",
+    "categoria": "Materias Obligatorias",
+    "level": 8
+  },
+  {
+    "id": "70.38",
+    "materia": "Levantamiento y Práctica Profesional II",
+    "creditos": 6,
+    "correlativas": "70.33-70.37",
+    "categoria": "Materias Obligatorias",
+    "level": 8
+  },
+  {
+    "id": "71.52",
+    "materia": "Agrimensura Legal IV",
+    "creditos": 6,
+    "correlativas": "71.30",
+    "categoria": "Materias Obligatorias",
+    "level": 8
+  },
+  {
+    "id": "70.24",
+    "materia": "Levantamientos Hidrográficos",
+    "creditos": 4,
+    "correlativas": "70.09",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "70.26",
+    "materia": "Hidráulica Agrícola y Saneamiento",
+    "creditos": 4,
+    "correlativas": "70.09",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "77.02",
+    "materia": "Introducción a la Ingeniería Ambiental",
+    "creditos": 4,
+    "requiere": 100,
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "68.11",
+    "materia": "Ordenamiento Rural y Urbano",
+    "creditos": 4,
+    "correlativas": "68.06-70.27",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "70.40",
+    "materia": "Geología Aplicada",
+    "creditos": 4,
+    "correlativas": "62.03-70.06",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "70.41",
+    "materia": "Oceanografía Física",
+    "creditos": 4,
+    "correlativas": "61.03-62.03",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "70.42",
+    "materia": "Sistemas de Información Geográfica II",
+    "creditos": 4,
+    "correlativas": "70.32",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "70.43",
+    "materia": "Topografía De Obra",
+    "creditos": 4,
+    "correlativas": "70.12-70.09",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "70.44",
+    "materia": "Dibujo Topográfico II",
+    "creditos": 4,
+    "correlativas": "70.04",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "78.xx",
+    "materia": "Idioma",
+    "creditos": 4,
+    "correlativas": "CBC",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "70.00",
+    "materia": "Tesis de Ingeniería en Agrimensura",
+    "creditos": 18,
+    "requiere": 140,
+    "categoria": "Fin de Carrera"
+  },
+  {
+    "id": "70.99",
+    "materia": "Trabajo Profesional de la Ingeniería en Agrimensura",
+    "creditos": 12,
+    "requiere": 140,
+    "categoria": "Fin de Carrera"
+  }
+]

--- a/src/data/alimentos-2000.json
+++ b/src/data/alimentos-2000.json
@@ -28,8 +28,8 @@
         "level": -1
     },
     {
-        "id": "CBC5",
-        "materia": "Química",
+        "id": "CBC90",
+        "materia": "Pensamiento Computacional",
         "creditos": 6,
         "categoria": "*CBC",
         "level": -1
@@ -47,7 +47,7 @@
         "creditos": 0,
         "categoria": "CBC",
         "level": 0,
-        "correlativas": "CBC66-CBC62-CBC3-CBC5-CBC24-CBC40"
+        "correlativas": "CBC66-CBC62-CBC3-CBC90-CBC24-CBC40"
     },
     {
         "id": "61.03",

--- a/src/data/alimentos-2000.json
+++ b/src/data/alimentos-2000.json
@@ -28,8 +28,8 @@
         "level": -1
     },
     {
-        "id": "CBC90",
-        "materia": "Pensamiento Computacional",
+        "id": "CBC5",
+        "materia": "Química / Pensamiento Computacional",
         "creditos": 6,
         "categoria": "*CBC",
         "level": -1
@@ -47,7 +47,7 @@
         "creditos": 0,
         "categoria": "CBC",
         "level": 0,
-        "correlativas": "CBC66-CBC62-CBC3-CBC90-CBC24-CBC40"
+        "correlativas": "CBC66-CBC62-CBC3-CBC5-CBC24-CBC40"
     },
     {
         "id": "61.03",

--- a/src/data/civil-2009.json
+++ b/src/data/civil-2009.json
@@ -28,8 +28,8 @@
         "level": -1
     },
     {
-        "id": "CBC5",
-        "materia": "Química",
+        "id": "CBC90",
+        "materia": "Pensamiento Computacional",
         "creditos": 6,
         "categoria": "*CBC",
         "level": -1
@@ -47,7 +47,7 @@
         "creditos": 0,
         "categoria": "CBC",
         "level": 0,
-        "correlativas": "CBC28-CBC27-CBC3-CBC5-CBC24-CBC40"
+        "correlativas": "CBC28-CBC27-CBC3-CBC90-CBC24-CBC40"
     },
     {
         "id": "82.01",

--- a/src/data/civil-2009.json
+++ b/src/data/civil-2009.json
@@ -28,8 +28,8 @@
         "level": -1
     },
     {
-        "id": "CBC90",
-        "materia": "Pensamiento Computacional",
+        "id": "CBC5",
+        "materia": "Química / Pensamiento Computacional",
         "creditos": 6,
         "categoria": "*CBC",
         "level": -1
@@ -47,7 +47,7 @@
         "creditos": 0,
         "categoria": "CBC",
         "level": 0,
-        "correlativas": "CBC28-CBC27-CBC3-CBC90-CBC24-CBC40"
+        "correlativas": "CBC28-CBC27-CBC3-CBC5-CBC24-CBC40"
     },
     {
         "id": "82.01",

--- a/src/data/electricista-2009.json
+++ b/src/data/electricista-2009.json
@@ -28,8 +28,8 @@
         "level": -1
     },
     {
-        "id": "CBC90",
-        "materia": "Pensamiento Computacional",
+        "id": "CBC5",
+        "materia": "Química / Pensamiento Computacional",
         "creditos": 6,
         "categoria": "*CBC",
         "level": -1
@@ -47,7 +47,7 @@
         "creditos": 0,
         "categoria": "CBC",
         "level": 0,
-        "correlativas": "CBC66-CBC62-CBC3-CBC90-CBC24-CBC40"
+        "correlativas": "CBC66-CBC62-CBC3-CBC5-CBC24-CBC40"
     },
     {
         "id": "81.01",

--- a/src/data/electricista-2009.json
+++ b/src/data/electricista-2009.json
@@ -28,8 +28,8 @@
         "level": -1
     },
     {
-        "id": "CBC5",
-        "materia": "Química",
+        "id": "CBC90",
+        "materia": "Pensamiento Computacional",
         "creditos": 6,
         "categoria": "*CBC",
         "level": -1
@@ -47,7 +47,7 @@
         "creditos": 0,
         "categoria": "CBC",
         "level": 0,
-        "correlativas": "CBC66-CBC62-CBC3-CBC5-CBC24-CBC40"
+        "correlativas": "CBC66-CBC62-CBC3-CBC90-CBC24-CBC40"
     },
     {
         "id": "81.01",

--- a/src/data/electronica-2009.json
+++ b/src/data/electronica-2009.json
@@ -28,8 +28,8 @@
         "level": -1
     },
     {
-        "id": "CBC90",
-        "materia": "Pensamiento Computacional",
+        "id": "CBC5",
+        "materia": "Química / Pensamiento Computacional",
         "creditos": 6,
         "categoria": "*CBC",
         "level": -1
@@ -47,7 +47,7 @@
         "creditos": 0,
         "categoria": "CBC",
         "level": 0,
-        "correlativas": "CBC66-CBC62-CBC3-CBC90-CBC24-CBC40"
+        "correlativas": "CBC66-CBC62-CBC3-CBC5-CBC24-CBC40"
     },
     {
         "id": "86.48",

--- a/src/data/electronica-2009.json
+++ b/src/data/electronica-2009.json
@@ -28,8 +28,8 @@
         "level": -1
     },
     {
-        "id": "CBC5",
-        "materia": "Química",
+        "id": "CBC90",
+        "materia": "Pensamiento Computacional",
         "creditos": 6,
         "categoria": "*CBC",
         "level": -1
@@ -47,7 +47,7 @@
         "creditos": 0,
         "categoria": "CBC",
         "level": 0,
-        "correlativas": "CBC66-CBC62-CBC3-CBC5-CBC24-CBC40"
+        "correlativas": "CBC66-CBC62-CBC3-CBC90-CBC24-CBC40"
     },
     {
         "id": "86.48",

--- a/src/data/industrial-2011.json
+++ b/src/data/industrial-2011.json
@@ -28,8 +28,8 @@
         "level": -1
     },
     {
-        "id": "CBC90",
-        "materia": "Pensamiento Computacional",
+        "id": "CBC5",
+        "materia": "Química / Pensamiento Computacional",
         "creditos": 6,
         "categoria": "*CBC",
         "level": -1
@@ -47,7 +47,7 @@
         "creditos": 0,
         "categoria": "CBC",
         "level": 0,
-        "correlativas": "CBC66-CBC62-CBC3-CBC90-CBC24-CBC40"
+        "correlativas": "CBC66-CBC62-CBC3-CBC5-CBC24-CBC40"
     },
     {
         "id": "81.01",

--- a/src/data/industrial-2011.json
+++ b/src/data/industrial-2011.json
@@ -28,8 +28,8 @@
         "level": -1
     },
     {
-        "id": "CBC5",
-        "materia": "Química",
+        "id": "CBC90",
+        "materia": "Pensamiento Computacional",
         "creditos": 6,
         "categoria": "*CBC",
         "level": -1
@@ -47,7 +47,7 @@
         "creditos": 0,
         "categoria": "CBC",
         "level": 0,
-        "correlativas": "CBC66-CBC62-CBC3-CBC5-CBC24-CBC40"
+        "correlativas": "CBC66-CBC62-CBC3-CBC90-CBC24-CBC40"
     },
     {
         "id": "81.01",

--- a/src/data/informatica-1986.json
+++ b/src/data/informatica-1986.json
@@ -28,8 +28,8 @@
         "level": -1
     },
     {
-        "id": "CBC90",
-        "materia": "Pensamiento Computacional",
+        "id": "CBC5",
+        "materia": "Química / Pensamiento Computacional",
         "creditos": 6,
         "categoria": "*CBC",
         "level": -1
@@ -47,7 +47,7 @@
         "creditos": 0,
         "categoria": "CBC",
         "level": 0,
-        "correlativas": "CBC28-CBC27-CBC3-CBC90-CBC24-CBC40"
+        "correlativas": "CBC28-CBC27-CBC3-CBC5-CBC24-CBC40"
     },
     {
         "id": "62.01",

--- a/src/data/informatica-1986.json
+++ b/src/data/informatica-1986.json
@@ -28,8 +28,8 @@
         "level": -1
     },
     {
-        "id": "CBC5",
-        "materia": "Química",
+        "id": "CBC90",
+        "materia": "Pensamiento Computacional",
         "creditos": 6,
         "categoria": "*CBC",
         "level": -1
@@ -47,7 +47,7 @@
         "creditos": 0,
         "categoria": "CBC",
         "level": 0,
-        "correlativas": "CBC28-CBC27-CBC3-CBC5-CBC24-CBC40"
+        "correlativas": "CBC28-CBC27-CBC3-CBC90-CBC24-CBC40"
     },
     {
         "id": "62.01",

--- a/src/data/mecanica-1986.json
+++ b/src/data/mecanica-1986.json
@@ -28,8 +28,8 @@
     "level": -1
   },
   {
-    "id": "CBC90",
-    "materia": "Pensamiento Computacional",
+    "id": "CBC5",
+    "materia": "Química / Pensamiento Computacional",
     "creditos": 6,
     "categoria": "*CBC",
     "level": -1
@@ -47,7 +47,7 @@
     "creditos": 0,
     "categoria": "CBC",
     "level": 0,
-    "correlativas": "CBC28-CBC27-CBC3-CBC90-CBC24-CBC40"
+    "correlativas": "CBC28-CBC27-CBC3-CBC5-CBC24-CBC40"
   },
   {
     "id": "62.01",

--- a/src/data/mecanica-1986.json
+++ b/src/data/mecanica-1986.json
@@ -28,8 +28,8 @@
     "level": -1
   },
   {
-    "id": "CBC5",
-    "materia": "Química",
+    "id": "CBC90",
+    "materia": "Pensamiento Computacional",
     "creditos": 6,
     "categoria": "*CBC",
     "level": -1
@@ -47,7 +47,7 @@
     "creditos": 0,
     "categoria": "CBC",
     "level": 0,
-    "correlativas": "CBC28-CBC27-CBC3-CBC5-CBC24-CBC40"
+    "correlativas": "CBC28-CBC27-CBC3-CBC90-CBC24-CBC40"
   },
   {
     "id": "62.01",

--- a/src/data/naval-1986.json
+++ b/src/data/naval-1986.json
@@ -28,8 +28,8 @@
     "level": -1
   },
   {
-    "id": "CBC5",
-    "materia": "Química",
+    "id": "CBC90",
+    "materia": "Pensamiento Computacional",
     "creditos": 6,
     "categoria": "*CBC",
     "level": -1
@@ -47,7 +47,7 @@
     "creditos": 0,
     "categoria": "CBC",
     "level": 0,
-    "correlativas": "CBC28-CBC27-CBC3-CBC5-CBC24-CBC40"
+    "correlativas": "CBC28-CBC27-CBC3-CBC90-CBC24-CBC40"
   },
   {
     "id": "61.08",

--- a/src/data/naval-1986.json
+++ b/src/data/naval-1986.json
@@ -28,8 +28,8 @@
     "level": -1
   },
   {
-    "id": "CBC90",
-    "materia": "Pensamiento Computacional",
+    "id": "CBC5",
+    "materia": "Química / Pensamiento Computacional",
     "creditos": 6,
     "categoria": "*CBC",
     "level": -1
@@ -47,7 +47,7 @@
     "creditos": 0,
     "categoria": "CBC",
     "level": 0,
-    "correlativas": "CBC28-CBC27-CBC3-CBC90-CBC24-CBC40"
+    "correlativas": "CBC28-CBC27-CBC3-CBC5-CBC24-CBC40"
   },
   {
     "id": "61.08",

--- a/src/data/petroleo-2015.json
+++ b/src/data/petroleo-2015.json
@@ -28,8 +28,8 @@
     "level": -1
   },
   {
-    "id": "CBC90",
-    "materia": "Pensamiento Computacional",
+    "id": "CBC5",
+    "materia": "Química / Pensamiento Computacional",
     "creditos": 6,
     "categoria": "*CBC",
     "level": -1
@@ -47,7 +47,7 @@
     "creditos": 0,
     "categoria": "CBC",
     "level": 0,
-    "correlativas": "CBC66-CBC62-CBC3-CBC90-CBC24-CBC40"
+    "correlativas": "CBC66-CBC62-CBC3-CBC5-CBC24-CBC40"
   },
   {
     "id": "83.01",

--- a/src/data/petroleo-2015.json
+++ b/src/data/petroleo-2015.json
@@ -28,8 +28,8 @@
     "level": -1
   },
   {
-    "id": "CBC5",
-    "materia": "Química",
+    "id": "CBC90",
+    "materia": "Pensamiento Computacional",
     "creditos": 6,
     "categoria": "*CBC",
     "level": -1
@@ -47,7 +47,7 @@
     "creditos": 0,
     "categoria": "CBC",
     "level": 0,
-    "correlativas": "CBC66-CBC62-CBC3-CBC5-CBC24-CBC40"
+    "correlativas": "CBC66-CBC62-CBC3-CBC90-CBC24-CBC40"
   },
   {
     "id": "83.01",

--- a/src/data/quimica-1986.json
+++ b/src/data/quimica-1986.json
@@ -1,1 +1,493 @@
-[{ "id": "CBC28", "materia": "Análisis Matemático", "creditos": 9, "categoria": "*CBC", "level": -2 }, { "id": "CBC27", "materia": "Álgebra", "creditos": 9, "categoria": "*CBC", "level": -2 }, { "id": "CBC24", "materia": "Introducción al Conocimiento de la Sociedad y el Estado", "creditos": 4, "categoria": "*CBC", "level": -2 }, { "id": "CBC3", "materia": "Física", "creditos": 6, "categoria": "*CBC", "level": -1 }, { "id": "CBC5", "materia": "Química", "creditos": 6, "categoria": "*CBC", "level": -1 }, { "id": "CBC40", "materia": "Introducción al Pensamiento Científico", "creditos": 4, "categoria": "*CBC", "level": -1 }, { "id": "CBC", "materia": "Ciclo Básico Común", "creditos": 0, "categoria": "CBC", "level": 0, "correlativas": "CBC28-CBC27-CBC3-CBC5-CBC24-CBC40" }, { "id": "61.03", "materia": "Análisis Matemático II A", "creditos": 8, "correlativas": "CBC", "categoria": "Materias Obligatorias", "level": 1 }, { "id": "62.01", "materia": "Física I A", "creditos": 8, "correlativas": "CBC", "categoria": "Materias Obligatorias", "level": 1 }, { "id": "63.02", "materia": "Química I", "creditos": 8, "correlativas": "CBC", "categoria": "Materias Obligatorias", "level": 1 }, { "id": "61.08", "materia": "Álgebra II A", "creditos": 8, "correlativas": "CBC", "categoria": "Materias Obligatorias", "level": 2 }, { "id": "62.04", "materia": "Física II B", "creditos": 6, "correlativas": "61.03-62.01", "categoria": "Materias Obligatorias", "level": 2 }, { "id": "75.01", "materia": "Computación", "creditos": 4, "correlativas": "CBC", "categoria": "Materias Obligatorias", "level": 2 }, { "id": "63.13", "materia": "Química Inorgánica", "creditos": 8, "correlativas": "63.02", "categoria": "Materias Obligatorias", "level": 2 }, { "id": "75.12", "materia": "Análisis Numérico I", "creditos": 6, "correlativas": "61.03-61.08-75.01", "categoria": "Materias Obligatorias", "level": 3 }, { "id": "76.45", "materia": "Termodinámica de los Procesos", "creditos": 10, "correlativas": "62.01-63.02", "categoria": "Materias Obligatorias", "level": 3 }, { "id": "63.14", "materia": "Química Orgánica", "creditos": 10, "correlativas": "63.13", "categoria": "Materias Obligatorias", "level": 3 }, { "id": "61.14", "materia": "Matemática Especial para Ingeniería Química", "creditos": 8, "correlativas": "61.03-61.08", "categoria": "Materias Obligatorias", "level": 4 }, { "id": "76.46", "materia": "Introducción a la Ingeniería Química", "creditos": 6, "correlativas": "76.45", "categoria": "Materias Obligatorias", "level": 4 }, { "id": "61.06", "materia": "Probabilidad y Estadística A", "creditos": 4, "correlativas": "61.03", "categoria": "Materias Obligatorias", "level": 4 }, { "id": "63.15", "materia": "Química Analítica Instrumental", "creditos": 8, "correlativas": "63.13-63.14-62.04", "categoria": "Materias Obligatorias", "level": 4 }, { "id": "65.48", "materia": "Laboratorio de Instalaciones Eléctricas", "creditos": 4, "correlativas": "62.04-76.46", "categoria": "Materias Obligatorias", "level": 5 }, { "id": "76.47", "materia": "Fenómenos de Transporte", "creditos": 10, "correlativas": "76.46-61.14", "categoria": "Materias Obligatorias", "level": 5 }, { "id": "76.48", "materia": "Evaluación de Propiedades Físicas", "creditos": 6, "correlativas": "76.45-61.06", "categoria": "Materias Obligatorias", "level": 5 }, { "id": "63.16", "materia": "Química Física", "creditos": 6, "correlativas": "63.13-76.45-63.15", "categoria": "Materias Obligatorias", "level": 5 }, { "id": "77.08", "materia": "Seguridad Ambiental y del Trabajo B", "creditos": 4, "requiere": 100, "requiereCBC": false, "categoria": "Materias Obligatorias", "level": 6 }, { "id": "76.49", "materia": "Operaciones Unitarias de Transferencia de Cantidad de Movimiento y Energía", "creditos": 10, "correlativas": "76.47", "categoria": "Materias Obligatorias", "level": 6 }, { "id": "76.52", "materia": "Operaciones Unitarias de Transferencia de Materia", "creditos": 10, "correlativas": "76.48-76.47", "categoria": "Materias Obligatorias", "level": 6 }, { "id": "76.54", "materia": "Instalaciones de Plantas de Procesos", "creditos": 8, "correlativas": "76.49", "categoria": "Materias Obligatorias", "level": 7 }, { "id": "76.53", "materia": "Diseño de Reactores", "creditos": 10, "correlativas": "76.49-63.16-75.12", "categoria": "Materias Obligatorias", "level": 7 }, { "id": "76.55", "materia": "Microbiología Industrial", "creditos": 6, "correlativas": "63.14", "categoria": "Materias Obligatorias", "level": 7 }, { "id": "76.56", "materia": "Instrumentación y Control de Plantas Químicas", "creditos": 10, "correlativas": "76.49-76.52", "categoria": "Materias Obligatorias", "level": 8 }, { "id": "76.57", "materia": "Diseño de Procesos", "creditos": 6, "correlativas": "76.52", "categoria": "Materias Obligatorias", "level": 8 }, { "id": "76.58", "materia": "Emisiones de Contaminantes Químicos y Biológicos", "creditos": 4, "correlativas": "76.52-76.55", "categoria": "Materias Obligatorias", "level": 8 }, { "id": "71.28", "materia": "Legislación y Ejercicio Profesional de la Ingeniería Química", "creditos": 4, "requiere": 140, "requiereCBC": false, "categoria": "Materias Obligatorias", "level": 9 }, { "id": "62.13", "materia": "Física III C", "creditos": 6, "correlativas": "62.04", "categoria": "Materias Electivas" }, { "id": "62.18", "materia": "Física de los Fluidos", "creditos": 4, "correlativas": "76.47", "categoria": "Materias Electivas" }, { "id": "63.10", "materia": "Termodinámica Estadística", "creditos": 6, "correlativas": "63.16", "categoria": "Materias Electivas" }, { "id": "67.13", "materia": "Conocimiento de Materiales I", "creditos": 6, "correlativas": "63.14", "categoria": "Materias Electivas" }, { "id": "67.57", "materia": "Elementos Finitos Avanzados en la Mecánica de Fluidos", "creditos": 6, "correlativas": "67.58", "categoria": "Materias Electivas" }, { "id": "67.58", "materia": "Intr. al Método de los Elementos Finitos", "creditos": 6, "correlativas": "75.12-76.47", "categoria": "Materias Electivas" }, { "id": "67.59", "materia": "Mecánica del Continuo", "creditos": 6, "correlativas": "67.60-76.47", "categoria": "Materias Electivas" }, { "id": "67.60", "materia": "Introducción al Análisis Tensorial", "creditos": 4, "correlativas": "61.03-61.08", "categoria": "Materias Electivas" }, { "id": "75.38", "materia": "Análisis Numérico II A", "creditos": 6, "correlativas": "75.12", "categoria": "Materias Electivas" }, { "id": "76.16", "materia": "Electroquímica", "creditos": 4, "correlativas": "63.16-76.47", "categoria": "Materias Electivas" }, { "id": "76.17", "materia": "Procesos Electroquímicos", "creditos": 4, "correlativas": "76.16", "categoria": "Materias Electivas" }, { "id": "76.18", "materia": "Fisicoquímica Especial", "creditos": 6, "correlativas": "63.16", "categoria": "Materias Electivas" }, { "id": "76.22", "materia": "Fundamentos de la Ing. de Reservorios", "creditos": 8, "correlativas": "76.47", "categoria": "Materias Electivas" }, { "id": "76.23", "materia": "Recuperación Asistida de Petróleo", "creditos": 4, "correlativas": "76.22", "categoria": "Materias Electivas" }, { "id": "76.24", "materia": "Fundamentos de la Simulación Numérica de Reservorio", "creditos": 6, "correlativas": "76.22", "categoria": "Materias Electivas" }, { "id": "76.25", "materia": "Explotación de Yacimientos", "creditos": 8, "correlativas": "62.04-76.46", "categoria": "Materias Electivas" }, { "id": "76.27", "materia": "Control Estadístico de Procesos", "creditos": 6, "correlativas": "61.06", "categoria": "Materias Electivas" }, { "id": "76.28", "materia": "Gestión Recursos en la Industria de Procesos", "creditos": 4, "correlativas": "76.47", "categoria": "Materias Electivas" }, { "id": "76.29", "materia": "Industria de Procesos", "creditos": 4, "correlativas": "76.52", "categoria": "Materias Electivas" }, { "id": "76.30", "materia": "Industrias Alimenticias", "creditos": 4, "correlativas": "76.49", "categoria": "Materias Electivas" }, { "id": "76.51", "materia": "Introducción a la Planificación Interactiva", "creditos": 4, "requiere": 140, "requiereCBC": false, "categoria": "Materias Electivas" }, { "id": "76.63", "materia": "Diseño Avanzado de Reactores", "creditos": 6, "correlativas": "76.53", "categoria": "Materias Electivas" }, { "id": "76.32", "materia": "Preservación de Alimentos", "creditos": 6, "correlativas": "76.49-76.52-76.55", "categoria": "Materias Electivas" }, { "id": "76.33", "materia": "Procesamiento Industrial de Alimentos", "creditos": 6, "correlativas": "76.32", "categoria": "Materias Electivas" }, { "id": "78.xx", "materia": "Idioma", "creditos": 4, "correlativas": "CBC", "categoria": "Materias Electivas" }, { "id": "71.53", "materia": "Evaluación de Proyectos de Plantas Químicas", "creditos": 6, "requiere": 140, "requiereCBC": false, "categoria": "Materias Obligatorias", "level": 9 }, { "id": "76.60", "materia": "Laboratorio de Operaciones y Procesos", "creditos": 4, "correlativas": "76.52-76.53-77.08", "categoria": "Materias Obligatorias", "level": 9 }, { "id": "76.61", "materia": "Bioingeniería", "creditos": 6, "correlativas": "76.52-76.53-76.55", "categoria": "Materias Obligatorias", "level": 9 }, { "id": "76.64", "materia": "Tesis de Ingeniería Química", "creditos": 18, "correlativas": "76.52-76.53", "categoria": "Fin de Carrera" }, { "id": "76.59-76.62", "materia": "Trabajo Profesional de Ingeniería Química", "creditos": 12, "correlativas": "76.52-76.53-76.56", "categoria": "Fin de Carrera" }]
+[
+  {
+    "id": "CBC28",
+    "materia": "Análisis Matemático",
+    "creditos": 9,
+    "categoria": "*CBC",
+    "level": -2
+  },
+  {
+    "id": "CBC27",
+    "materia": "Álgebra",
+    "creditos": 9,
+    "categoria": "*CBC",
+    "level": -2
+  },
+  {
+    "id": "CBC24",
+    "materia": "Introducción al Conocimiento de la Sociedad y el Estado",
+    "creditos": 4,
+    "categoria": "*CBC",
+    "level": -2
+  },
+  {
+    "id": "CBC3",
+    "materia": "Física",
+    "creditos": 6,
+    "categoria": "*CBC",
+    "level": -1
+  },
+  {
+    "id": "CBC90",
+    "materia": "Pensamiento Computacional",
+    "creditos": 6,
+    "categoria": "*CBC",
+    "level": -1
+  },
+  {
+    "id": "CBC40",
+    "materia": "Introducción al Pensamiento Científico",
+    "creditos": 4,
+    "categoria": "*CBC",
+    "level": -1
+  },
+  {
+    "id": "CBC",
+    "materia": "Ciclo Básico Común",
+    "creditos": 0,
+    "categoria": "CBC",
+    "level": 0,
+    "correlativas": "CBC28-CBC27-CBC3-CBC90-CBC24-CBC40"
+  },
+  {
+    "id": "61.03",
+    "materia": "Análisis Matemático II A",
+    "creditos": 8,
+    "correlativas": "CBC",
+    "categoria": "Materias Obligatorias",
+    "level": 1
+  },
+  {
+    "id": "62.01",
+    "materia": "Física I A",
+    "creditos": 8,
+    "correlativas": "CBC",
+    "categoria": "Materias Obligatorias",
+    "level": 1
+  },
+  {
+    "id": "63.02",
+    "materia": "Química I",
+    "creditos": 8,
+    "correlativas": "CBC",
+    "categoria": "Materias Obligatorias",
+    "level": 1
+  },
+  {
+    "id": "61.08",
+    "materia": "Álgebra II A",
+    "creditos": 8,
+    "correlativas": "CBC",
+    "categoria": "Materias Obligatorias",
+    "level": 2
+  },
+  {
+    "id": "62.04",
+    "materia": "Física II B",
+    "creditos": 6,
+    "correlativas": "61.03-62.01",
+    "categoria": "Materias Obligatorias",
+    "level": 2
+  },
+  {
+    "id": "75.01",
+    "materia": "Computación",
+    "creditos": 4,
+    "correlativas": "CBC",
+    "categoria": "Materias Obligatorias",
+    "level": 2
+  },
+  {
+    "id": "63.13",
+    "materia": "Química Inorgánica",
+    "creditos": 8,
+    "correlativas": "63.02",
+    "categoria": "Materias Obligatorias",
+    "level": 2
+  },
+  {
+    "id": "75.12",
+    "materia": "Análisis Numérico I",
+    "creditos": 6,
+    "correlativas": "61.03-61.08-75.01",
+    "categoria": "Materias Obligatorias",
+    "level": 3
+  },
+  {
+    "id": "76.45",
+    "materia": "Termodinámica de los Procesos",
+    "creditos": 10,
+    "correlativas": "62.01-63.02",
+    "categoria": "Materias Obligatorias",
+    "level": 3
+  },
+  {
+    "id": "63.14",
+    "materia": "Química Orgánica",
+    "creditos": 10,
+    "correlativas": "63.13",
+    "categoria": "Materias Obligatorias",
+    "level": 3
+  },
+  {
+    "id": "61.14",
+    "materia": "Matemática Especial para Ingeniería Química",
+    "creditos": 8,
+    "correlativas": "61.03-61.08",
+    "categoria": "Materias Obligatorias",
+    "level": 4
+  },
+  {
+    "id": "76.46",
+    "materia": "Introducción a la Ingeniería Química",
+    "creditos": 6,
+    "correlativas": "76.45",
+    "categoria": "Materias Obligatorias",
+    "level": 4
+  },
+  {
+    "id": "61.06",
+    "materia": "Probabilidad y Estadística A",
+    "creditos": 4,
+    "correlativas": "61.03",
+    "categoria": "Materias Obligatorias",
+    "level": 4
+  },
+  {
+    "id": "63.15",
+    "materia": "Química Analítica Instrumental",
+    "creditos": 8,
+    "correlativas": "63.13-63.14-62.04",
+    "categoria": "Materias Obligatorias",
+    "level": 4
+  },
+  {
+    "id": "65.48",
+    "materia": "Laboratorio de Instalaciones Eléctricas",
+    "creditos": 4,
+    "correlativas": "62.04-76.46",
+    "categoria": "Materias Obligatorias",
+    "level": 5
+  },
+  {
+    "id": "76.47",
+    "materia": "Fenómenos de Transporte",
+    "creditos": 10,
+    "correlativas": "76.46-61.14",
+    "categoria": "Materias Obligatorias",
+    "level": 5
+  },
+  {
+    "id": "76.48",
+    "materia": "Evaluación de Propiedades Físicas",
+    "creditos": 6,
+    "correlativas": "76.45-61.06",
+    "categoria": "Materias Obligatorias",
+    "level": 5
+  },
+  {
+    "id": "63.16",
+    "materia": "Química Física",
+    "creditos": 6,
+    "correlativas": "63.13-76.45-63.15",
+    "categoria": "Materias Obligatorias",
+    "level": 5
+  },
+  {
+    "id": "77.08",
+    "materia": "Seguridad Ambiental y del Trabajo B",
+    "creditos": 4,
+    "requiere": 100,
+    "requiereCBC": false,
+    "categoria": "Materias Obligatorias",
+    "level": 6
+  },
+  {
+    "id": "76.49",
+    "materia": "Operaciones Unitarias de Transferencia de Cantidad de Movimiento y Energía",
+    "creditos": 10,
+    "correlativas": "76.47",
+    "categoria": "Materias Obligatorias",
+    "level": 6
+  },
+  {
+    "id": "76.52",
+    "materia": "Operaciones Unitarias de Transferencia de Materia",
+    "creditos": 10,
+    "correlativas": "76.48-76.47",
+    "categoria": "Materias Obligatorias",
+    "level": 6
+  },
+  {
+    "id": "76.54",
+    "materia": "Instalaciones de Plantas de Procesos",
+    "creditos": 8,
+    "correlativas": "76.49",
+    "categoria": "Materias Obligatorias",
+    "level": 7
+  },
+  {
+    "id": "76.53",
+    "materia": "Diseño de Reactores",
+    "creditos": 10,
+    "correlativas": "76.49-63.16-75.12",
+    "categoria": "Materias Obligatorias",
+    "level": 7
+  },
+  {
+    "id": "76.55",
+    "materia": "Microbiología Industrial",
+    "creditos": 6,
+    "correlativas": "63.14",
+    "categoria": "Materias Obligatorias",
+    "level": 7
+  },
+  {
+    "id": "76.56",
+    "materia": "Instrumentación y Control de Plantas Químicas",
+    "creditos": 10,
+    "correlativas": "76.49-76.52",
+    "categoria": "Materias Obligatorias",
+    "level": 8
+  },
+  {
+    "id": "76.57",
+    "materia": "Diseño de Procesos",
+    "creditos": 6,
+    "correlativas": "76.52",
+    "categoria": "Materias Obligatorias",
+    "level": 8
+  },
+  {
+    "id": "76.58",
+    "materia": "Emisiones de Contaminantes Químicos y Biológicos",
+    "creditos": 4,
+    "correlativas": "76.52-76.55",
+    "categoria": "Materias Obligatorias",
+    "level": 8
+  },
+  {
+    "id": "71.28",
+    "materia": "Legislación y Ejercicio Profesional de la Ingeniería Química",
+    "creditos": 4,
+    "requiere": 140,
+    "requiereCBC": false,
+    "categoria": "Materias Obligatorias",
+    "level": 9
+  },
+  {
+    "id": "62.13",
+    "materia": "Física III C",
+    "creditos": 6,
+    "correlativas": "62.04",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "62.18",
+    "materia": "Física de los Fluidos",
+    "creditos": 4,
+    "correlativas": "76.47",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "63.10",
+    "materia": "Termodinámica Estadística",
+    "creditos": 6,
+    "correlativas": "63.16",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "67.13",
+    "materia": "Conocimiento de Materiales I",
+    "creditos": 6,
+    "correlativas": "63.14",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "67.57",
+    "materia": "Elementos Finitos Avanzados en la Mecánica de Fluidos",
+    "creditos": 6,
+    "correlativas": "67.58",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "67.58",
+    "materia": "Intr. al Método de los Elementos Finitos",
+    "creditos": 6,
+    "correlativas": "75.12-76.47",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "67.59",
+    "materia": "Mecánica del Continuo",
+    "creditos": 6,
+    "correlativas": "67.60-76.47",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "67.60",
+    "materia": "Introducción al Análisis Tensorial",
+    "creditos": 4,
+    "correlativas": "61.03-61.08",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "75.38",
+    "materia": "Análisis Numérico II A",
+    "creditos": 6,
+    "correlativas": "75.12",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "76.16",
+    "materia": "Electroquímica",
+    "creditos": 4,
+    "correlativas": "63.16-76.47",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "76.17",
+    "materia": "Procesos Electroquímicos",
+    "creditos": 4,
+    "correlativas": "76.16",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "76.18",
+    "materia": "Fisicoquímica Especial",
+    "creditos": 6,
+    "correlativas": "63.16",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "76.22",
+    "materia": "Fundamentos de la Ing. de Reservorios",
+    "creditos": 8,
+    "correlativas": "76.47",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "76.23",
+    "materia": "Recuperación Asistida de Petróleo",
+    "creditos": 4,
+    "correlativas": "76.22",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "76.24",
+    "materia": "Fundamentos de la Simulación Numérica de Reservorio",
+    "creditos": 6,
+    "correlativas": "76.22",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "76.25",
+    "materia": "Explotación de Yacimientos",
+    "creditos": 8,
+    "correlativas": "62.04-76.46",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "76.27",
+    "materia": "Control Estadístico de Procesos",
+    "creditos": 6,
+    "correlativas": "61.06",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "76.28",
+    "materia": "Gestión Recursos en la Industria de Procesos",
+    "creditos": 4,
+    "correlativas": "76.47",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "76.29",
+    "materia": "Industria de Procesos",
+    "creditos": 4,
+    "correlativas": "76.52",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "76.30",
+    "materia": "Industrias Alimenticias",
+    "creditos": 4,
+    "correlativas": "76.49",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "76.51",
+    "materia": "Introducción a la Planificación Interactiva",
+    "creditos": 4,
+    "requiere": 140,
+    "requiereCBC": false,
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "76.63",
+    "materia": "Diseño Avanzado de Reactores",
+    "creditos": 6,
+    "correlativas": "76.53",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "76.32",
+    "materia": "Preservación de Alimentos",
+    "creditos": 6,
+    "correlativas": "76.49-76.52-76.55",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "76.33",
+    "materia": "Procesamiento Industrial de Alimentos",
+    "creditos": 6,
+    "correlativas": "76.32",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "78.xx",
+    "materia": "Idioma",
+    "creditos": 4,
+    "correlativas": "CBC",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "71.53",
+    "materia": "Evaluación de Proyectos de Plantas Químicas",
+    "creditos": 6,
+    "requiere": 140,
+    "requiereCBC": false,
+    "categoria": "Materias Obligatorias",
+    "level": 9
+  },
+  {
+    "id": "76.60",
+    "materia": "Laboratorio de Operaciones y Procesos",
+    "creditos": 4,
+    "correlativas": "76.52-76.53-77.08",
+    "categoria": "Materias Obligatorias",
+    "level": 9
+  },
+  {
+    "id": "76.61",
+    "materia": "Bioingeniería",
+    "creditos": 6,
+    "correlativas": "76.52-76.53-76.55",
+    "categoria": "Materias Obligatorias",
+    "level": 9
+  },
+  {
+    "id": "76.64",
+    "materia": "Tesis de Ingeniería Química",
+    "creditos": 18,
+    "correlativas": "76.52-76.53",
+    "categoria": "Fin de Carrera"
+  },
+  {
+    "id": "76.59-76.62",
+    "materia": "Trabajo Profesional de Ingeniería Química",
+    "creditos": 12,
+    "correlativas": "76.52-76.53-76.56",
+    "categoria": "Fin de Carrera"
+  }
+]

--- a/src/data/quimica-1986.json
+++ b/src/data/quimica-1986.json
@@ -28,8 +28,8 @@
     "level": -1
   },
   {
-    "id": "CBC90",
-    "materia": "Pensamiento Computacional",
+    "id": "CBC5",
+    "materia": "Química / Pensamiento Computacional",
     "creditos": 6,
     "categoria": "*CBC",
     "level": -1
@@ -47,7 +47,7 @@
     "creditos": 0,
     "categoria": "CBC",
     "level": 0,
-    "correlativas": "CBC28-CBC27-CBC3-CBC90-CBC24-CBC40"
+    "correlativas": "CBC28-CBC27-CBC3-CBC5-CBC24-CBC40"
   },
   {
     "id": "61.03",

--- a/src/data/sistemas-1986.json
+++ b/src/data/sistemas-1986.json
@@ -28,8 +28,8 @@
     "level": -1
   },
   {
-    "id": "CBC90",
-    "materia": "Pensamiento Computacional",
+    "id": "CBC5",
+    "materia": "Química / Pensamiento Computacional",
     "creditos": 6,
     "categoria": "*CBC",
     "level": -1
@@ -47,7 +47,7 @@
     "creditos": 0,
     "categoria": "CBC",
     "level": 0,
-    "correlativas": "CBC28-CBC27-CBC3-CBC90-CBC24-CBC40"
+    "correlativas": "CBC28-CBC27-CBC3-CBC5-CBC24-CBC40"
   },
   {
     "id": "61.03",

--- a/src/data/sistemas-1986.json
+++ b/src/data/sistemas-1986.json
@@ -1,1 +1,402 @@
-[{ "id": "CBC28", "materia": "Análisis Matemático", "creditos": 9, "categoria": "*CBC", "level": -2 }, { "id": "CBC27", "materia": "Álgebra", "creditos": 9, "categoria": "*CBC", "level": -2 }, { "id": "CBC24", "materia": "Introducción al Conocimiento de la Sociedad y el Estado", "creditos": 4, "categoria": "*CBC", "level": -2 }, { "id": "CBC3", "materia": "Física", "creditos": 6, "categoria": "*CBC", "level": -1 }, { "id": "CBC5", "materia": "Química", "creditos": 6, "categoria": "*CBC", "level": -1 }, { "id": "CBC40", "materia": "Introducción al Pensamiento Científico", "creditos": 4, "categoria": "*CBC", "level": -1 }, { "id": "CBC", "materia": "Ciclo Básico Común", "creditos": 0, "categoria": "CBC", "level": 0, "correlativas": "CBC28-CBC27-CBC3-CBC5-CBC24-CBC40" }, { "id": "61.03", "materia": "Análisis Matemático II", "creditos": 8, "correlativas": "CBC", "categoria": "Materias Obligatorias", "level": 1 }, { "id": "61.08", "materia": "Álgebra II", "creditos": 8, "correlativas": "CBC", "categoria": "Materias Obligatorias", "level": 1 }, { "id": "75.40", "materia": "Algoritmos y Programación I", "creditos": 6, "correlativas": "CBC", "categoria": "Materias Obligatorias", "level": 1 }, { "id": "61.07", "materia": "Matemática Discreta", "creditos": 6, "correlativas": "CBC", "categoria": "Materias Obligatorias", "level": 2 }, { "id": "75.03", "materia": "Organización del Computador", "creditos": 8, "correlativas": "75.40", "categoria": "Materias Obligatorias", "level": 2 }, { "id": "75.41", "materia": "Algoritmos y Programación II", "creditos": 6, "correlativas": "75.40", "categoria": "Materias Obligatorias", "level": 2 }, { "id": "71.12", "materia": "Estructura de las Organizaciones", "creditos": 6, "correlativas": "CBC", "categoria": "Materias Obligatorias", "level": 3 }, { "id": "61.09", "materia": "Probabilidad y Estadística B", "creditos": 6, "correlativas": "61.03-61.08", "categoria": "Materias Obligatorias", "level": 3 }, { "id": "75.06", "materia": "Organización de Datos", "creditos": 6, "correlativas": "75.03-75.41", "categoria": "Materias Obligatorias", "level": 3 }, { "id": "75.07", "materia": "Algoritmos y Programación III", "creditos": 6, "correlativas": "75.41", "categoria": "Materias Obligatorias", "level": 3 }, { "id": "71.13", "materia": "Información en las Organizaciones", "creditos": 6, "correlativas": "71.12", "categoria": "Materias Obligatorias", "level": 4 }, { "id": "75.08", "materia": "Sistemas Operativos", "creditos": 6, "correlativas": "75.06", "categoria": "Materias Obligatorias", "level": 4 }, { "id": "75.09", "materia": "Análisis de la Información", "creditos": 6, "correlativas": "75.06-75.07", "categoria": "Materias Obligatorias", "level": 4 }, { "id": "75.42", "materia": "Taller de Programación I", "creditos": 4, "correlativas": "75.03-75.41", "categoria": "Materias Obligatorias", "level": 4 }, { "id": "71.14", "materia": "Modelos y Optimización I", "creditos": 6, "correlativas": "61.03-61.07-61.08", "categoria": "Materias Obligatorias", "level": 5 }, { "id": "75.15", "materia": "Base de Datos", "creditos": 6, "correlativas": "75.09", "categoria": "Materias Obligatorias", "level": 5 }, { "id": "75.10", "materia": "Técnicas de Diseño", "creditos": 6, "correlativas": "75.09", "categoria": "Materias Obligatorias", "level": 5 }, { "id": "71.15", "materia": "Modelos y Optimización II", "creditos": 6, "correlativas": "61.09-71.14", "categoria": "Materias Obligatorias", "level": 6 }, { "id": "71.16", "materia": "Administración de Proyectos", "creditos": 6, "correlativas": "71.12-71.14", "categoria": "Materias Obligatorias", "level": 6 }, { "id": "75.17", "materia": "Implantación de Sistemas", "creditos": 6, "correlativas": "75.10", "categoria": "Materias Obligatorias", "level": 6 }, { "id": "75.18", "materia": "Proyectos Informáticos", "creditos": 6, "correlativas": "71.13-71.16-75.17", "categoria": "Materias Obligatorias", "level": 6 }, { "id": "71.17", "materia": "Derecho Informático", "creditos": 4, "correlativas": "75.17", "categoria": "Materias Electivas" }, { "id": "71.18", "materia": "Estructura Económica Argentina", "creditos": 4, "correlativas": "CBC", "categoria": "Materias Electivas" }, { "id": "71.20", "materia": "Modelos y Optimización III", "creditos": 6, "correlativas": "71.15", "categoria": "Materias Electivas" }, { "id": "78.xx", "materia": "Idioma", "creditos": 4, "correlativas": "CBC", "categoria": "Materias Electivas" }, { "id": "71.58", "materia": "Análisis y Resolución de Problemas de Sistemas", "creditos": 6, "correlativas": "71.15", "categoria": "Materias Electivas" }, { "id": "71.46", "materia": "Ingeniería Económica", "creditos": 6, "correlativas": "71.13", "categoria": "Materias Electivas" }, { "id": "75.12", "materia": "Análisis Numérico I", "creditos": 6, "correlativas": "61.03-61.08-75.41", "categoria": "Materias Electivas" }, { "id": "75.14", "materia": "Lenguajes Formales", "creditos": 6, "correlativas": "61.07", "categoria": "Materias Electivas" }, { "id": "75.16", "materia": "Lenguajes de Programación", "creditos": 6, "correlativas": "75.14", "categoria": "Materias Electivas" }, { "id": "75.19", "materia": "Teoría de Comunicación", "creditos": 6, "correlativas": "75.08", "categoria": "Materias Electivas" }, { "id": "75.20", "materia": "Arquitecturas y Configuración", "creditos": 6, "correlativas": "75.08", "categoria": "Materias Electivas" }, { "id": "75.22", "materia": "Concurrencia", "creditos": 8, "correlativas": "75.08", "categoria": "Materias Electivas" }, { "id": "75.23", "materia": "Inteligencia Artificial", "creditos": 6, "correlativas": "75.41", "categoria": "Materias Electivas" }, { "id": "75.24", "materia": "Teoría de la Programación", "creditos": 4, "correlativas": "75.41", "categoria": "Materias Electivas" }, { "id": "75.26", "materia": "Simulación", "creditos": 6, "correlativas": "61.09", "categoria": "Materias Electivas" }, { "id": "75.27", "materia": "Algoritmos y Programación IV", "creditos": 6, "correlativas": "75.07", "categoria": "Materias Electivas" }, { "id": "75.29", "materia": "Teoría de Algoritmos I", "creditos": 6, "correlativas": "61.07-75.41", "categoria": "Materias Electivas" }, { "id": "75.32", "materia": "Práctica Profesional", "creditos": 3, "correlativas": "71.13-75.10-75.15", "categoria": "Materias Electivas" }, { "id": "75.33", "materia": "Redes y Teleprocesamientos I", "creditos": 6, "correlativas": "75.08-75.15", "categoria": "Materias Electivas" }, { "id": "75.34", "materia": "Redes y Teleprocesamientos II", "creditos": 6, "correlativas": "75.33", "categoria": "Materias Electivas" }, { "id": "75.36", "materia": "Seminario y Lógica de Bases de Datos", "creditos": 3, "correlativas": "75.15", "categoria": "Materias Electivas" }, { "id": "75.38", "materia": "Análisis Numérico II A", "creditos": 6, "correlativas": "75.12", "categoria": "Materias Electivas" }, { "id": "75.39", "materia": "Aplicaciones Informáticas", "creditos": 6, "correlativas": "75.08-75.09", "categoria": "Materias Electivas" }, { "id": "75.50", "materia": "Introducción a los Sistemas Inteligentes", "creditos": 6, "correlativas": "61.09-71.14", "categoria": "Materias Electivas" }, { "id": "75.71", "materia": "Seminario de Ingeniería de Informática I", "creditos": 3, "correlativas": "75.07", "categoria": "Materias Electivas" }, { "id": "75.72", "materia": "Seminario de Ingeniería de Informática II", "creditos": 3, "correlativas": "75.06-75.41", "categoria": "Materias Electivas" }]
+[
+  {
+    "id": "CBC28",
+    "materia": "Análisis Matemático",
+    "creditos": 9,
+    "categoria": "*CBC",
+    "level": -2
+  },
+  {
+    "id": "CBC27",
+    "materia": "Álgebra",
+    "creditos": 9,
+    "categoria": "*CBC",
+    "level": -2
+  },
+  {
+    "id": "CBC24",
+    "materia": "Introducción al Conocimiento de la Sociedad y el Estado",
+    "creditos": 4,
+    "categoria": "*CBC",
+    "level": -2
+  },
+  {
+    "id": "CBC3",
+    "materia": "Física",
+    "creditos": 6,
+    "categoria": "*CBC",
+    "level": -1
+  },
+  {
+    "id": "CBC90",
+    "materia": "Pensamiento Computacional",
+    "creditos": 6,
+    "categoria": "*CBC",
+    "level": -1
+  },
+  {
+    "id": "CBC40",
+    "materia": "Introducción al Pensamiento Científico",
+    "creditos": 4,
+    "categoria": "*CBC",
+    "level": -1
+  },
+  {
+    "id": "CBC",
+    "materia": "Ciclo Básico Común",
+    "creditos": 0,
+    "categoria": "CBC",
+    "level": 0,
+    "correlativas": "CBC28-CBC27-CBC3-CBC90-CBC24-CBC40"
+  },
+  {
+    "id": "61.03",
+    "materia": "Análisis Matemático II",
+    "creditos": 8,
+    "correlativas": "CBC",
+    "categoria": "Materias Obligatorias",
+    "level": 1
+  },
+  {
+    "id": "61.08",
+    "materia": "Álgebra II",
+    "creditos": 8,
+    "correlativas": "CBC",
+    "categoria": "Materias Obligatorias",
+    "level": 1
+  },
+  {
+    "id": "75.40",
+    "materia": "Algoritmos y Programación I",
+    "creditos": 6,
+    "correlativas": "CBC",
+    "categoria": "Materias Obligatorias",
+    "level": 1
+  },
+  {
+    "id": "61.07",
+    "materia": "Matemática Discreta",
+    "creditos": 6,
+    "correlativas": "CBC",
+    "categoria": "Materias Obligatorias",
+    "level": 2
+  },
+  {
+    "id": "75.03",
+    "materia": "Organización del Computador",
+    "creditos": 8,
+    "correlativas": "75.40",
+    "categoria": "Materias Obligatorias",
+    "level": 2
+  },
+  {
+    "id": "75.41",
+    "materia": "Algoritmos y Programación II",
+    "creditos": 6,
+    "correlativas": "75.40",
+    "categoria": "Materias Obligatorias",
+    "level": 2
+  },
+  {
+    "id": "71.12",
+    "materia": "Estructura de las Organizaciones",
+    "creditos": 6,
+    "correlativas": "CBC",
+    "categoria": "Materias Obligatorias",
+    "level": 3
+  },
+  {
+    "id": "61.09",
+    "materia": "Probabilidad y Estadística B",
+    "creditos": 6,
+    "correlativas": "61.03-61.08",
+    "categoria": "Materias Obligatorias",
+    "level": 3
+  },
+  {
+    "id": "75.06",
+    "materia": "Organización de Datos",
+    "creditos": 6,
+    "correlativas": "75.03-75.41",
+    "categoria": "Materias Obligatorias",
+    "level": 3
+  },
+  {
+    "id": "75.07",
+    "materia": "Algoritmos y Programación III",
+    "creditos": 6,
+    "correlativas": "75.41",
+    "categoria": "Materias Obligatorias",
+    "level": 3
+  },
+  {
+    "id": "71.13",
+    "materia": "Información en las Organizaciones",
+    "creditos": 6,
+    "correlativas": "71.12",
+    "categoria": "Materias Obligatorias",
+    "level": 4
+  },
+  {
+    "id": "75.08",
+    "materia": "Sistemas Operativos",
+    "creditos": 6,
+    "correlativas": "75.06",
+    "categoria": "Materias Obligatorias",
+    "level": 4
+  },
+  {
+    "id": "75.09",
+    "materia": "Análisis de la Información",
+    "creditos": 6,
+    "correlativas": "75.06-75.07",
+    "categoria": "Materias Obligatorias",
+    "level": 4
+  },
+  {
+    "id": "75.42",
+    "materia": "Taller de Programación I",
+    "creditos": 4,
+    "correlativas": "75.03-75.41",
+    "categoria": "Materias Obligatorias",
+    "level": 4
+  },
+  {
+    "id": "71.14",
+    "materia": "Modelos y Optimización I",
+    "creditos": 6,
+    "correlativas": "61.03-61.07-61.08",
+    "categoria": "Materias Obligatorias",
+    "level": 5
+  },
+  {
+    "id": "75.15",
+    "materia": "Base de Datos",
+    "creditos": 6,
+    "correlativas": "75.09",
+    "categoria": "Materias Obligatorias",
+    "level": 5
+  },
+  {
+    "id": "75.10",
+    "materia": "Técnicas de Diseño",
+    "creditos": 6,
+    "correlativas": "75.09",
+    "categoria": "Materias Obligatorias",
+    "level": 5
+  },
+  {
+    "id": "71.15",
+    "materia": "Modelos y Optimización II",
+    "creditos": 6,
+    "correlativas": "61.09-71.14",
+    "categoria": "Materias Obligatorias",
+    "level": 6
+  },
+  {
+    "id": "71.16",
+    "materia": "Administración de Proyectos",
+    "creditos": 6,
+    "correlativas": "71.12-71.14",
+    "categoria": "Materias Obligatorias",
+    "level": 6
+  },
+  {
+    "id": "75.17",
+    "materia": "Implantación de Sistemas",
+    "creditos": 6,
+    "correlativas": "75.10",
+    "categoria": "Materias Obligatorias",
+    "level": 6
+  },
+  {
+    "id": "75.18",
+    "materia": "Proyectos Informáticos",
+    "creditos": 6,
+    "correlativas": "71.13-71.16-75.17",
+    "categoria": "Materias Obligatorias",
+    "level": 6
+  },
+  {
+    "id": "71.17",
+    "materia": "Derecho Informático",
+    "creditos": 4,
+    "correlativas": "75.17",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "71.18",
+    "materia": "Estructura Económica Argentina",
+    "creditos": 4,
+    "correlativas": "CBC",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "71.20",
+    "materia": "Modelos y Optimización III",
+    "creditos": 6,
+    "correlativas": "71.15",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "78.xx",
+    "materia": "Idioma",
+    "creditos": 4,
+    "correlativas": "CBC",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "71.58",
+    "materia": "Análisis y Resolución de Problemas de Sistemas",
+    "creditos": 6,
+    "correlativas": "71.15",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "71.46",
+    "materia": "Ingeniería Económica",
+    "creditos": 6,
+    "correlativas": "71.13",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "75.12",
+    "materia": "Análisis Numérico I",
+    "creditos": 6,
+    "correlativas": "61.03-61.08-75.41",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "75.14",
+    "materia": "Lenguajes Formales",
+    "creditos": 6,
+    "correlativas": "61.07",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "75.16",
+    "materia": "Lenguajes de Programación",
+    "creditos": 6,
+    "correlativas": "75.14",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "75.19",
+    "materia": "Teoría de Comunicación",
+    "creditos": 6,
+    "correlativas": "75.08",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "75.20",
+    "materia": "Arquitecturas y Configuración",
+    "creditos": 6,
+    "correlativas": "75.08",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "75.22",
+    "materia": "Concurrencia",
+    "creditos": 8,
+    "correlativas": "75.08",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "75.23",
+    "materia": "Inteligencia Artificial",
+    "creditos": 6,
+    "correlativas": "75.41",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "75.24",
+    "materia": "Teoría de la Programación",
+    "creditos": 4,
+    "correlativas": "75.41",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "75.26",
+    "materia": "Simulación",
+    "creditos": 6,
+    "correlativas": "61.09",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "75.27",
+    "materia": "Algoritmos y Programación IV",
+    "creditos": 6,
+    "correlativas": "75.07",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "75.29",
+    "materia": "Teoría de Algoritmos I",
+    "creditos": 6,
+    "correlativas": "61.07-75.41",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "75.32",
+    "materia": "Práctica Profesional",
+    "creditos": 3,
+    "correlativas": "71.13-75.10-75.15",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "75.33",
+    "materia": "Redes y Teleprocesamientos I",
+    "creditos": 6,
+    "correlativas": "75.08-75.15",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "75.34",
+    "materia": "Redes y Teleprocesamientos II",
+    "creditos": 6,
+    "correlativas": "75.33",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "75.36",
+    "materia": "Seminario y Lógica de Bases de Datos",
+    "creditos": 3,
+    "correlativas": "75.15",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "75.38",
+    "materia": "Análisis Numérico II A",
+    "creditos": 6,
+    "correlativas": "75.12",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "75.39",
+    "materia": "Aplicaciones Informáticas",
+    "creditos": 6,
+    "correlativas": "75.08-75.09",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "75.50",
+    "materia": "Introducción a los Sistemas Inteligentes",
+    "creditos": 6,
+    "correlativas": "61.09-71.14",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "75.71",
+    "materia": "Seminario de Ingeniería de Informática I",
+    "creditos": 3,
+    "correlativas": "75.07",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "75.72",
+    "materia": "Seminario de Ingeniería de Informática II",
+    "creditos": 3,
+    "correlativas": "75.06-75.41",
+    "categoria": "Materias Electivas"
+  }
+]

--- a/src/data/sistemas-2014.json
+++ b/src/data/sistemas-2014.json
@@ -28,8 +28,8 @@
     "level": -1
   },
   {
-    "id": "CBC5",
-    "materia": "Química",
+    "id": "CBC90",
+    "materia": "Pensamiento Computacional",
     "creditos": 6,
     "categoria": "*CBC",
     "level": -1
@@ -47,7 +47,7 @@
     "creditos": 0,
     "categoria": "CBC",
     "level": 0,
-    "correlativas": "CBC28-CBC27-CBC3-CBC5-CBC24-CBC40"
+    "correlativas": "CBC28-CBC27-CBC3-CBC90-CBC24-CBC40"
   },
   {
     "id": "81.01",

--- a/src/data/sistemas-2014.json
+++ b/src/data/sistemas-2014.json
@@ -28,8 +28,8 @@
     "level": -1
   },
   {
-    "id": "CBC90",
-    "materia": "Pensamiento Computacional",
+    "id": "CBC5",
+    "materia": "Química / Pensamiento Computacional",
     "creditos": 6,
     "categoria": "*CBC",
     "level": -1
@@ -47,7 +47,7 @@
     "creditos": 0,
     "categoria": "CBC",
     "level": 0,
-    "correlativas": "CBC28-CBC27-CBC3-CBC90-CBC24-CBC40"
+    "correlativas": "CBC28-CBC27-CBC3-CBC5-CBC24-CBC40"
   },
   {
     "id": "81.01",


### PR DESCRIPTION
Hola que tal, como la materia Quimica del CBC fue remplazada por Pensamiento Computacional, crei que lo mejor seria actualizar la pagina, y remplazar quimica por pensamiento computacional.
No estoy seguro de cuantos creditos otorga pero por lo que lei es el remplazo de Quimica asi que decidi dejarlo con la misma cantidad de creditos osea 6.
Algunos archivos (agrimensura-2006, quimicas-1986, sistemas-1986) fueron autoformateados por el editor de texto, de ser una linea larga a estar en un lindo formato compartido por los demas archivos.
Si me equivoque en alguna cosa, o hay algo que cambiar diganmelo.

Fuentes:
- https://www.fi.uba.ar/noticias/el-cbc-de-ingenieria-con-una-nueva-asignatura
- https://cms.fi.uba.ar/uploads/RESCS_2022_9_E_UBA_REC_0e893ce8e6.pdf
- https://ubaxxi.uba.ar/portfolio-items/pensamiento-computacional-90/