### PR TITLE
Fix: al editar materias optativas mantener el orden

### DIFF
--- a/src/Graph.js
+++ b/src/Graph.js
@@ -528,10 +528,7 @@ const Graph = (userContext) => {
         newstate = prevstate.filter((o) => o.id !== value.id)
         break;
       case 'edit':
-        newstate = [
-          ...prevstate.filter((o) => o.id !== value.id),
-          { ...value }
-        ]
+        newstate = prevstate.map(o => o.id === value.id ? value : o);
         break;
       default:
         return newstate;


### PR DESCRIPTION
Buenas! Al editar las materias optativas, la materia que estés editando pasa a estar última y puede buggearse la UI.
Se puede probar agregando dos materias y sumándole créditos a la primera. El NumberInput se vuelve loco y sigue incrementado el valor hasta que se pone el mouse encima del boton para decrementar.

Con este fix, el nuevo estado mantiene el orden de las materias y la UI ya no se buggea.