### PR TITLE
Simplificar el final de carrera (Tesis / TPP) carreras del plan 2020

### DIFF
--- a/src/carreras.js
+++ b/src/carreras.js
@@ -105,7 +105,6 @@ export const CARRERAS = [
     link: "https://fi.uba.ar/grado/carreras/ingenieria-en-informatica/plan-de-estudios",
     ano: 2020,
     graph: require("./data/informatica-2020.json"),
-    finDeCarrera: [{ id: "tif", materia: "TIF" }],
     creditos: {
       total: 226,
       electivas: 24,
@@ -115,6 +114,14 @@ export const CARRERAS = [
           nombrecorto: "Inglés",
           bg: COLORS.enfinal[50],
           color: "enfinal",
+        },
+      ],
+      materias: [
+        {
+          id: "TIF",
+          nombrecorto: "TIF",
+          bg: COLORS.findecarrera[50],
+          color: "findecarrera",
         },
       ],
     },
@@ -146,7 +153,6 @@ export const CARRERAS = [
     link: "https://fi.uba.ar/grado/carreras/ingenieria-en-agrimensura/plan-de-estudios",
     ano: 2020,
     graph: require("./data/agrimensura-2020.json"),
-    finDeCarrera: [{ id: "tif", materia: "TIF" }],
     creditos: {
       total: 227,
       electivas: 16,
@@ -156,6 +162,14 @@ export const CARRERAS = [
           nombrecorto: "Inglés",
           bg: COLORS.enfinal[50],
           color: "enfinal",
+        },
+      ],
+      materias: [
+        {
+          id: "TIF",
+          nombrecorto: "TIF",
+          bg: COLORS.findecarrera[50],
+          color: "findecarrera",
         },
       ],
     },
@@ -189,7 +203,6 @@ export const CARRERAS = [
     link: "https://fi.uba.ar/grado/carreras/ingenieria-de-alimentos/plan-de-estudios",
     ano: 2020,
     graph: require("./data/alimentos-2020.json"),
-    finDeCarrera: [{ id: "tif", materia: "TIF" }],
     creditos: {
       total: 243,
       electivas: 12,
@@ -199,6 +212,14 @@ export const CARRERAS = [
           nombrecorto: "Inglés",
           bg: COLORS.enfinal[50],
           color: "enfinal",
+        },
+      ],
+      materias: [
+        {
+          id: "TIF",
+          nombrecorto: "TIF",
+          bg: COLORS.findecarrera[50],
+          color: "findecarrera",
         },
       ],
     },
@@ -240,7 +261,6 @@ export const CARRERAS = [
     link: "https://fi.uba.ar/grado/carreras/ingenieria-civil/plan-de-estudios",
     ano: 2020,
     graph: require("./data/civil-2020.json"),
-    finDeCarrera: [{ id: "tif", materia: "TIF" }],
     creditos: {
       total: 251,
       electivas: 24,
@@ -250,6 +270,14 @@ export const CARRERAS = [
           nombrecorto: "Inglés",
           bg: COLORS.enfinal[50],
           color: "enfinal",
+        },
+      ],
+      materias: [
+        {
+          id: "TIF",
+          nombrecorto: "TIF",
+          bg: COLORS.findecarrera[50],
+          color: "findecarrera",
         },
       ],
     },
@@ -328,7 +356,6 @@ export const CARRERAS = [
     link: "https://fi.uba.ar/grado/carreras/ingenieria-electronica/plan-de-estudios",
     ano: 2020,
     graph: require("./data/electronica-2020.json"),
-    finDeCarrera: [{ id: "tif", materia: "TIF" }],
     creditos: {
       total: 228,
       electivas: 24,
@@ -338,6 +365,14 @@ export const CARRERAS = [
           nombrecorto: "Inglés",
           bg: COLORS.enfinal[50],
           color: "enfinal",
+        },
+      ],
+      materias: [
+        {
+          id: "TIF",
+          nombrecorto: "TIF",
+          bg: COLORS.findecarrera[50],
+          color: "findecarrera",
         },
       ],
     },
@@ -375,7 +410,6 @@ export const CARRERAS = [
     link: "https://fi.uba.ar/grado/carreras/ingenieria-industrial/plan-de-estudios",
     ano: 2020,
     graph: require("./data/industrial-2020.json"),
-    finDeCarrera: [{ id: "tif", materia: "TIF" }],
     creditos: {
       total: 236,
       electivas: 24,
@@ -386,11 +420,13 @@ export const CARRERAS = [
           bg: COLORS.enfinal[50],
           color: "enfinal",
         },
+      ],
+      materias: [
         {
-          nombre: "Actividades profesionales",
-          nombrecorto: "Práctica Profesional",
-          bg: COLORS.habilitadas[50],
-          color: "habilitadas",
+          id: "TIF",
+          nombrecorto: "TIF",
+          bg: COLORS.findecarrera[50],
+          color: "findecarrera",
         },
       ],
     },
@@ -482,14 +518,8 @@ export const CARRERAS = [
       electivas: 14,
       materias: [
         {
-          id: "TIF1",
-          nombrecorto: "TIF1",
-          bg: COLORS.findecarrera[50],
-          color: "findecarrera",
-        },
-        {
-          id: "TIF2",
-          nombrecorto: "TIF2",
+          id: "TIF",
+          nombrecorto: "TIF",
           bg: COLORS.findecarrera[50],
           color: "findecarrera",
         },
@@ -523,7 +553,6 @@ export const CARRERAS = [
     link: "https://fi.uba.ar/grado/carreras/ingenieria-quimica/plan-de-estudios",
     ano: 2020,
     graph: require("./data/quimica-2020.json"),
-    finDeCarrera: [{ id: "tif", materia: "TIF" }],
     creditos: {
       total: 231,
       electivas: 14,
@@ -533,6 +562,14 @@ export const CARRERAS = [
           nombrecorto: "Inglés",
           bg: COLORS.enfinal[50],
           color: "enfinal",
+        },
+      ],
+      materias: [
+        {
+          id: "TIF",
+          nombrecorto: "TIF",
+          bg: COLORS.findecarrera[50],
+          color: "findecarrera",
         },
       ],
     },

--- a/src/carreras.js
+++ b/src/carreras.js
@@ -29,6 +29,16 @@ import { COLORS } from "./theme";
 
 export const CARRERAS = [
   {
+    id: "sistemasviejo",
+    link: "https://fi.uba.ar/grado/carreras/lic-en-analisis-de-sistemas/plan-de-estudios",
+    ano: 1986,
+    graph: require("./data/sistemas-1986.json"),
+    creditos: {
+      total: 208,
+      electivas: 40,
+    },
+  },
+  {
     id: "sistemas",
     link: "https://fi.uba.ar/grado/carreras/lic-en-analisis-de-sistemas/plan-de-estudios",
     ano: 2014,
@@ -95,10 +105,7 @@ export const CARRERAS = [
     link: "https://fi.uba.ar/grado/carreras/ingenieria-en-informatica/plan-de-estudios",
     ano: 2020,
     graph: require("./data/informatica-2020.json"),
-    finDeCarrera: [
-      { id: "tesis", materia: "TESIS" },
-      { id: "tpp", materia: "TPP" },
-    ],
+    finDeCarrera: [{ id: "tif", materia: "TIF" }],
     creditos: {
       total: 226,
       electivas: 24,
@@ -108,12 +115,6 @@ export const CARRERAS = [
           nombrecorto: "Inglés",
           bg: COLORS.enfinal[50],
           color: "enfinal",
-        },
-        {
-          nombre: "Actividades profesionales de 192 horas",
-          nombrecorto: "Práctica Profesional",
-          bg: COLORS.habilitadas[50],
-          color: "habilitadas",
         },
       ],
     },
@@ -145,10 +146,7 @@ export const CARRERAS = [
     link: "https://fi.uba.ar/grado/carreras/ingenieria-en-agrimensura/plan-de-estudios",
     ano: 2020,
     graph: require("./data/agrimensura-2020.json"),
-    finDeCarrera: [
-      { id: "tesis", materia: "TESIS" },
-      { id: "tpp", materia: "TPP" },
-    ],
+    finDeCarrera: [{ id: "tif", materia: "TIF" }],
     creditos: {
       total: 227,
       electivas: 16,
@@ -158,12 +156,6 @@ export const CARRERAS = [
           nombrecorto: "Inglés",
           bg: COLORS.enfinal[50],
           color: "enfinal",
-        },
-        {
-          nombre: "Actividades profesionales de 192 horas",
-          nombrecorto: "Práctica Profesional",
-          bg: COLORS.habilitadas[50],
-          color: "habilitadas",
         },
       ],
     },
@@ -197,10 +189,7 @@ export const CARRERAS = [
     link: "https://fi.uba.ar/grado/carreras/ingenieria-de-alimentos/plan-de-estudios",
     ano: 2020,
     graph: require("./data/alimentos-2020.json"),
-    finDeCarrera: [
-      { id: "tesis", materia: "TESIS" },
-      { id: "tpp", materia: "TPP" },
-    ],
+    finDeCarrera: [{ id: "tif", materia: "TIF" }],
     creditos: {
       total: 243,
       electivas: 12,
@@ -210,12 +199,6 @@ export const CARRERAS = [
           nombrecorto: "Inglés",
           bg: COLORS.enfinal[50],
           color: "enfinal",
-        },
-        {
-          nombre: "Actividades profesionales de 192 horas",
-          nombrecorto: "Práctica Profesional",
-          bg: COLORS.habilitadas[50],
-          color: "habilitadas",
         },
       ],
     },
@@ -257,10 +240,7 @@ export const CARRERAS = [
     link: "https://fi.uba.ar/grado/carreras/ingenieria-civil/plan-de-estudios",
     ano: 2020,
     graph: require("./data/civil-2020.json"),
-    finDeCarrera: [
-      { id: "tesis", materia: "TESIS" },
-      { id: "tpp", materia: "TPP" },
-    ],
+    finDeCarrera: [{ id: "tif", materia: "TIF" }],
     creditos: {
       total: 251,
       electivas: 24,
@@ -270,12 +250,6 @@ export const CARRERAS = [
           nombrecorto: "Inglés",
           bg: COLORS.enfinal[50],
           color: "enfinal",
-        },
-        {
-          nombre: "Actividades profesionales de 192 horas",
-          nombrecorto: "Práctica Profesional",
-          bg: COLORS.habilitadas[50],
-          color: "habilitadas",
         },
       ],
     },
@@ -354,10 +328,7 @@ export const CARRERAS = [
     link: "https://fi.uba.ar/grado/carreras/ingenieria-electronica/plan-de-estudios",
     ano: 2020,
     graph: require("./data/electronica-2020.json"),
-    finDeCarrera: [
-      { id: "tesis", materia: "TESIS" },
-      { id: "tpp", materia: "TPP" },
-    ],
+    finDeCarrera: [{ id: "tif", materia: "TIF" }],
     creditos: {
       total: 228,
       electivas: 24,
@@ -367,12 +338,6 @@ export const CARRERAS = [
           nombrecorto: "Inglés",
           bg: COLORS.enfinal[50],
           color: "enfinal",
-        },
-        {
-          nombre: "Actividades profesionales de 192 horas",
-          nombrecorto: "Práctica Profesional",
-          bg: COLORS.habilitadas[50],
-          color: "habilitadas",
         },
       ],
     },
@@ -410,10 +375,7 @@ export const CARRERAS = [
     link: "https://fi.uba.ar/grado/carreras/ingenieria-industrial/plan-de-estudios",
     ano: 2020,
     graph: require("./data/industrial-2020.json"),
-    finDeCarrera: [
-      { id: "tesis", materia: "TESIS" },
-      { id: "tpp", materia: "TPP" },
-    ],
+    finDeCarrera: [{ id: "tif", materia: "TIF" }],
     creditos: {
       total: 236,
       electivas: 24,
@@ -520,14 +482,14 @@ export const CARRERAS = [
       electivas: 14,
       materias: [
         {
-          id: "TPP1",
-          nombrecorto: "TPP1",
+          id: "TIF1",
+          nombrecorto: "TIF1",
           bg: COLORS.findecarrera[50],
           color: "findecarrera",
         },
         {
-          id: "TPP2",
-          nombrecorto: "TPP2",
+          id: "TIF2",
+          nombrecorto: "TIF2",
           bg: COLORS.findecarrera[50],
           color: "findecarrera",
         },
@@ -538,12 +500,6 @@ export const CARRERAS = [
           nombrecorto: "Inglés",
           bg: COLORS.enfinal[50],
           color: "enfinal",
-        },
-        {
-          nombre: "Actividades profesionales de 192 horas",
-          nombrecorto: "Práctica Profesional",
-          bg: COLORS.habilitadas[50],
-          color: "habilitadas",
         },
       ],
     },
@@ -567,10 +523,7 @@ export const CARRERAS = [
     link: "https://fi.uba.ar/grado/carreras/ingenieria-quimica/plan-de-estudios",
     ano: 2020,
     graph: require("./data/quimica-2020.json"),
-    finDeCarrera: [
-      { id: "tesis", materia: "TESIS" },
-      { id: "tpp", materia: "TPP" },
-    ],
+    finDeCarrera: [{ id: "tif", materia: "TIF" }],
     creditos: {
       total: 231,
       electivas: 14,
@@ -581,23 +534,7 @@ export const CARRERAS = [
           bg: COLORS.enfinal[50],
           color: "enfinal",
         },
-        {
-          nombre: "Actividades profesionales de 192 horas",
-          nombrecorto: "Práctica Profesional",
-          bg: COLORS.habilitadas[50],
-          color: "habilitadas",
-        },
       ],
-    },
-  },
-  {
-    id: "sistemasviejo",
-    link: "https://fi.uba.ar/grado/carreras/lic-en-analisis-de-sistemas/plan-de-estudios",
-    ano: 1986,
-    graph: require("./data/sistemas-1986.json"),
-    creditos: {
-      total: 208,
-      electivas: 40,
     },
   },
 ];

--- a/src/data/agrimensura-2020.json
+++ b/src/data/agrimensura-2020.json
@@ -330,20 +330,6 @@
     "level": 7
   },
   {
-    "id": "TPP",
-    "materia": "Trabajo Profesional de Ingeniería en Agrimensura",
-    "creditos": 12,
-    "correlativas": "MNS",
-    "categoria": "Fin de Carrera"
-  },
-  {
-    "id": "TESIS",
-    "materia": "Tesis de Ingeniería en Agrimensura",
-    "creditos": 12,
-    "correlativas": "MNS",
-    "categoria": "Fin de Carrera"
-  },
-  {
     "id": "GE",
     "materia": "Geoestadística",
     "creditos": 4,
@@ -482,5 +468,12 @@
     "creditos": 3,
     "correlativas": "AD-IA",
     "categoria": "Materias Electivas"
+  },
+  {
+    "id": "TIF",
+    "materia": "Trabajo Final Integrador",
+    "creditos": 12,
+    "correlativas": "MNS",
+    "categoria": "Fin de Carrera"
   }
 ]

--- a/src/data/agrimensura-2020.json
+++ b/src/data/agrimensura-2020.json
@@ -474,6 +474,6 @@
     "materia": "Trabajo Final Integrador",
     "creditos": 12,
     "correlativas": "MNS",
-    "categoria": "Fin de Carrera"
+    "categoria": "Fin de Carrera (Obligatorio)"
   }
 ]

--- a/src/data/alimentos-2020.json
+++ b/src/data/alimentos-2020.json
@@ -339,20 +339,6 @@
     "level": 9
   },
   {
-    "id": "TPP",
-    "materia": "Trabajo Profesional de Ingeniería de Alimentos",
-    "creditos": 12,
-    "correlativas": "FPA1-IPP",
-    "categoria": "Fin de Carrera"
-  },
-  {
-    "id": "TESIS",
-    "materia": "Tesis de Ingeniería de Alimentos",
-    "creditos": 12,
-    "correlativas": "FPA1-IPP",
-    "categoria": "Fin de Carrera"
-  },
-  {
     "id": "DDP",
     "materia": "Diseño de Producto",
     "creditos": 4,
@@ -449,5 +435,12 @@
     "creditos": 6,
     "correlativas": "FPA2",
     "categoria": "Materias Electivas"
+  },
+  {
+    "id": "TIF",
+    "materia": "Trabajo Final Integrador",
+    "creditos": 12,
+    "correlativas": "FPA1-IPP",
+    "categoria": "Fin de Carrera"
   }
 ]

--- a/src/data/alimentos-2020.json
+++ b/src/data/alimentos-2020.json
@@ -441,6 +441,6 @@
     "materia": "Trabajo Final Integrador",
     "creditos": 12,
     "correlativas": "FPA1-IPP",
-    "categoria": "Fin de Carrera"
+    "categoria": "Fin de Carrera (Obligatorio)"
   }
 ]

--- a/src/data/civil-2020.json
+++ b/src/data/civil-2020.json
@@ -350,24 +350,6 @@
     "level": 9
   },
   {
-    "id": "TPP",
-    "materia": "Trabajo Profesional de Ingeniería Civil",
-    "creditos": 12,
-    "correlativas": "ESTR",
-    "requiere": 158,
-    "requiereCBC": true,
-    "categoria": "Fin de Carrera"
-  },
-  {
-    "id": "TESIS",
-    "materia": "Tesis de Ingeniería Civil",
-    "creditos": 12,
-    "correlativas": "ESTR",
-    "requiere": 158,
-    "requiereCBC": true,
-    "categoria": "Fin de Carrera"
-  },
-  {
     "id": "MS",
     "materia": "Mecánica del Sólido",
     "creditos": 6,
@@ -725,5 +707,14 @@
     "creditos": 3,
     "correlativas": "PROBA-IA",
     "categoria": "Materias Electivas"
+  },
+  {
+    "id": "TIF",
+    "materia": "Trabajo Final Inegrador",
+    "creditos": 12,
+    "correlativas": "ESTR",
+    "requiere": 158,
+    "requiereCBC": true,
+    "categoria": "Fin de Carrera"
   }
 ]

--- a/src/data/civil-2020.json
+++ b/src/data/civil-2020.json
@@ -715,6 +715,6 @@
     "correlativas": "ESTR",
     "requiere": 158,
     "requiereCBC": true,
-    "categoria": "Fin de Carrera"
+    "categoria": "Fin de Carrera (Obligatorio)"
   }
 ]

--- a/src/data/electronica-2020.json
+++ b/src/data/electronica-2020.json
@@ -569,6 +569,6 @@
     "materia": "Trabajo Final Integrador",
     "creditos": 12,
     "correlativas": "PP",
-    "categoria": "Fin de Carrera"
+    "categoria": "Fin de Carrera (Obligatorio)"
   }
 ]

--- a/src/data/electronica-2020.json
+++ b/src/data/electronica-2020.json
@@ -565,15 +565,8 @@
     "categoria": "Materias Electivas"
   },
   {
-    "id": "TPP",
-    "materia": "Trabajo Profesional de Ingeniería Electrónica",
-    "creditos": 12,
-    "correlativas": "PP",
-    "categoria": "Fin de Carrera"
-  },
-  {
-    "id": "TESIS",
-    "materia": "Tesis de Ingeniería Electrónica",
+    "id": "TIF",
+    "materia": "Trabajo Final Integrador",
     "creditos": 12,
     "correlativas": "PP",
     "categoria": "Fin de Carrera"

--- a/src/data/industrial-2020.json
+++ b/src/data/industrial-2020.json
@@ -500,6 +500,6 @@
     "creditos": 12,
     "requiere": 140,
     "requiereCBC": true,
-    "categoria": "Fin de Carrera"
+    "categoria": "Fin de Carrera (Obligatorio)"
   }
 ]

--- a/src/data/industrial-2020.json
+++ b/src/data/industrial-2020.json
@@ -495,16 +495,8 @@
     "categoria": "Materias Electivas"
   },
   {
-    "id": "TPP",
-    "materia": "Trabajo Profesional de Ingeniería Industrial",
-    "creditos": 12,
-    "requiere": 140,
-    "requiereCBC": true,
-    "categoria": "Fin de Carrera"
-  },
-  {
-    "id": "TESIS",
-    "materia": "Tesis de Ingeniería Industrial",
+    "id": "TIF",
+    "materia": "Trabajo Final Integrador",
     "creditos": 12,
     "requiere": 140,
     "requiereCBC": true,

--- a/src/data/informatica-2020.json
+++ b/src/data/informatica-2020.json
@@ -403,6 +403,6 @@
     "creditos": 12,
     "requiere": 140,
     "requiereCBC": true,
-    "categoria": "Fin de Carrera"
+    "categoria": "Fin de Carrera (Obligatorio)"
   }
 ]

--- a/src/data/informatica-2020.json
+++ b/src/data/informatica-2020.json
@@ -398,16 +398,8 @@
     "categoria": "Materias Electivas"
   },
   {
-    "id": "TPP",
-    "materia": "Trabajo Profesional de Ingeniería Informática",
-    "creditos": 12,
-    "requiere": 140,
-    "requiereCBC": true,
-    "categoria": "Fin de Carrera"
-  },
-  {
-    "id": "TESIS",
-    "materia": "Tesis de Ingeniería Informática",
+    "id": "TIF",
+    "materia": "Trabajo Final Integrador",
     "creditos": 12,
     "requiere": 140,
     "requiereCBC": true,

--- a/src/data/petroleo-2020.json
+++ b/src/data/petroleo-2020.json
@@ -308,20 +308,6 @@
     "level": 9
   },
   {
-    "id": "TPP1",
-    "materia": "Trabajo Integrador Final de Ingeniería en Petróleo I",
-    "creditos": 4,
-    "correlativas": "IR-PYE-SPH-PI2",
-    "categoria": "Fin de Carrera (Obligatorio)"
-  },
-  {
-    "id": "TPP2",
-    "materia": "Trabajo Integrador Final de Ingeniería en Petróleo II",
-    "creditos": 8,
-    "correlativas": "TPP1",
-    "categoria": "Fin de Carrera (Obligatorio)"
-  },
-  {
     "id": "MR",
     "materia": "Modelado de Reservorios",
     "creditos": 4,
@@ -444,5 +430,19 @@
     "creditos": 3,
     "correlativas": "IA-AD",
     "categoria": "Materias Electivas"
+  },
+  {
+    "id": "TIF1",
+    "materia": "Trabajo Integrador Final I",
+    "creditos": 4,
+    "correlativas": "IR-PYE-SPH-PI2",
+    "categoria": "Fin de Carrera"
+  },
+  {
+    "id": "TIF2",
+    "materia": "Trabajo Integrador Final II",
+    "creditos": 8,
+    "correlativas": "TIF1",
+    "categoria": "Fin de Carrera"
   }
 ]

--- a/src/data/petroleo-2020.json
+++ b/src/data/petroleo-2020.json
@@ -432,17 +432,10 @@
     "categoria": "Materias Electivas"
   },
   {
-    "id": "TIF1",
-    "materia": "Trabajo Integrador Final I",
-    "creditos": 4,
-    "correlativas": "IR-PYE-SPH-PI2",
-    "categoria": "Fin de Carrera"
-  },
-  {
-    "id": "TIF2",
-    "materia": "Trabajo Integrador Final II",
-    "creditos": 8,
-    "correlativas": "TIF1",
-    "categoria": "Fin de Carrera"
+    "id": "TIF",
+    "materia": "Trabajo Integrador Final",
+    "creditos": 12,
+    "correlativas": "IR-PROBA-SPH-PI2",
+    "categoria": "Fin de Carrera (Obligatorio)"
   }
 ]

--- a/src/data/quimica-2020.json
+++ b/src/data/quimica-2020.json
@@ -441,6 +441,6 @@
     "materia": "Trabajo Final Integrador",
     "creditos": 12,
     "correlativas": "LOP-EPPQ-DCP",
-    "categoria": "Fin de Carrera"
+    "categoria": "Fin de Carrera (Obligatorio)"
   }
 ]

--- a/src/data/quimica-2020.json
+++ b/src/data/quimica-2020.json
@@ -276,20 +276,6 @@
     "level": 8
   },
   {
-    "id": "TPP",
-    "materia": "Trabajo Profesional de Ingeniería Química",
-    "creditos": 12,
-    "correlativas": "LOP-EPPQ-DCP",
-    "categoria": "Fin de Carrera"
-  },
-  {
-    "id": "TESIS",
-    "materia": "Tesis de Ingeniería Química",
-    "creditos": 12,
-    "correlativas": "LOP-EPPQ-DCP",
-    "categoria": "Fin de Carrera"
-  },
-  {
     "id": "TMEC",
     "materia": "Tecnologías para la Mitigación de Emisiones de Carbono",
     "creditos": 4,
@@ -449,5 +435,12 @@
     "creditos": 6,
     "correlativas": "QI",
     "categoria": "Materias Electivas"
+  },
+  {
+    "id": "TIF",
+    "materia": "Trabajo Final Integrador",
+    "creditos": 12,
+    "correlativas": "LOP-EPPQ-DCP",
+    "categoria": "Fin de Carrera"
   }
 ]


### PR DESCRIPTION
closes #209 

Hola @FdelMazo como andas.

- Remplace en los respectivos archivos json (en la carpeta data) las materias de TESIS y TPP por TIF
- Remplace en carreras.js el finDeCarrera a contener solamente la materia TIF
- Movi en carreras.js sistemasviejo al comienzo antes de sistemas (para mantener el orden, viste por ej: esta quimica y abajo quimica-2020)

Encontras algun error o algo que mejorar?

Tengo una duda:

En las carreras del plan 2020 (excepto petroleo-2020) tienen solamente el TIF, por ende seria logico que no haya que elegir el final de carrera (que en el userMenu aparezca solamente Cerrar Sesion), como por ejemplo analista de sistemas 2014, que por defecto esta seleccionado la materia de fin de carrera, Trabajo Profesional.