### PR TITLE
Arreglar texto de los nodos de las carreras overflowing

### DIFF
--- a/src/Node.js
+++ b/src/Node.js
@@ -11,7 +11,7 @@ const ALWAYS_SHOW = [
 function breakWords(string) {
   let broken = "";
   string.split(" ").forEach((element) => {
-    if (element.length < 5) broken += " " + element;
+    if (element.length < 4) broken += " " + element;
     else broken += "\n" + element;
   });
   return broken.trim();


### PR DESCRIPTION
Hola @FdelMazo , en la carrera de Ingenieria en Petroleo 2020, el texto de la materia "Propiedades de la Roca y los Fluidos de los Reservorios" como que es muy ancho y sobretapa los nodos de alado, esto lo solucione haciendo que en la funcion breakWords de Node.js, las palabras se agreguen a broken si su longitud es menor a 4.

Antes:
![antes](https://github.com/FdelMazo/FIUBA-Map/assets/96202715/89a249e0-1a5b-4242-8c90-54e101aedf32)

Despues
![despues](https://github.com/FdelMazo/FIUBA-Map/assets/96202715/ce927c63-7ee0-4688-ad4e-d4a6b7c45cf7)
