### PR TITLE
Add plan 2020 electrica y mecanica

### DIFF
--- a/src/carreras.js
+++ b/src/carreras.js
@@ -494,7 +494,8 @@ export const CARRERAS = [
   },
   {
     id: "mecanica-2020",
-    link: "https://fi.uba.ar/grado/carreras/ingenieria-mecanica/plan-de-estudios",
+    link: "https://sites.google.com/fi.uba.ar/academica/nuevos-planes-de-estudio/plan-ing-mec%C3%A1nica/",
+    beta: true,
     ano: 2020,
     graph: require("./data/mecanica-2020.json"),
     creditos: {

--- a/src/carreras.js
+++ b/src/carreras.js
@@ -311,6 +311,32 @@ export const CARRERAS = [
     },
   },
   {
+    id: "energia-electrica-2020",
+    link: "https://fi.uba.ar/grado/carreras/ingenieria-industrial/plan-de-estudios",
+    ano: 2020,
+    graph: require("./data/energia-electrica-2020.json"),
+    creditos: {
+      total: 250,
+      electivas: 18,
+      checkbox: [
+        {
+          nombre: "Prueba de nivel de idioma inglés",
+          nombrecorto: "Inglés",
+          bg: COLORS.enfinal[50],
+          color: "enfinal",
+        },
+      ],
+      materias: [
+        {
+          id: "TIF",
+          nombrecorto: "TIF",
+          bg: COLORS.findecarrera[50],
+          color: "findecarrera",
+        },
+      ],
+    },
+  },
+  {
     id: "electronica",
     link: "https://fi.uba.ar/grado/carreras/ingenieria-electronica/plan-de-estudios",
     ano: 2009,
@@ -616,9 +642,9 @@ export const PLANES = [
     planes: ["alimentos", "alimentos-2020"],
   },
   {
-    nombre: "Ingeniería Electricista",
+    nombre: "Ingeniería en Energía Eléctrica",
     nombrecorto: "Electricista",
-    planes: ["electricista"],
+    planes: ["electricista", "energia-electrica-2020"],
   },
   {
     nombre: "Ingeniería Electrónica",

--- a/src/carreras.js
+++ b/src/carreras.js
@@ -467,6 +467,32 @@ export const CARRERAS = [
     eligeOrientaciones: true,
   },
   {
+    id: "mecanica-2020",
+    link: "https://fi.uba.ar/grado/carreras/ingenieria-mecanica/plan-de-estudios",
+    ano: 2020,
+    graph: require("./data/mecanica-2020.json"),
+    creditos: {
+      total: 250,
+      electivas: 14,
+      checkbox: [
+        {
+          nombre: "Prueba de nivel de idioma inglés",
+          nombrecorto: "Inglés",
+          bg: COLORS.enfinal[50],
+          color: "enfinal",
+        },
+      ],
+      materias: [
+        {
+          id: "TIF",
+          nombrecorto: "TIF",
+          bg: COLORS.findecarrera[50],
+          color: "findecarrera",
+        },
+      ],
+    },
+  },
+  {
     id: "naval",
     link: "https://fi.uba.ar/grado/carreras/ingenieria-naval-y-mecanica/plan-de-estudios",
     ano: 1986,
@@ -622,7 +648,7 @@ export const PLANES = [
   {
     nombre: "Ingeniería Mecánica",
     nombrecorto: "Mecánica",
-    planes: ["mecanica"],
+    planes: ["mecanica", "mecanica-2020"],
   },
   {
     nombre: "Ingeniería Naval y Mecánica",

--- a/src/carreras.js
+++ b/src/carreras.js
@@ -312,7 +312,8 @@ export const CARRERAS = [
   },
   {
     id: "energia-electrica-2020",
-    link: "https://fi.uba.ar/grado/carreras/ingenieria-industrial/plan-de-estudios",
+    link: "https://sites.google.com/fi.uba.ar/academica/nuevos-planes-de-estudio/plan-ing-en-energ%C3%ADa-el%C3%A9ctrica/",
+    beta: true,
     ano: 2020,
     graph: require("./data/energia-electrica-2020.json"),
     creditos: {

--- a/src/data/energia-electrica-2020.json
+++ b/src/data/energia-electrica-2020.json
@@ -1,0 +1,452 @@
+[
+  {
+    "id": "CBC66",
+    "materia": "Análisis Matemático A",
+    "creditos": 9,
+    "categoria": "*CBC",
+    "level": -2
+  },
+  {
+    "id": "CBC62",
+    "materia": "Álgebra A",
+    "creditos": 9,
+    "categoria": "*CBC",
+    "level": -2
+  },
+  {
+    "id": "CBC24",
+    "materia": "Introducción al Conocimiento de la Sociedad y el Estado",
+    "creditos": 4,
+    "categoria": "*CBC",
+    "level": -2
+  },
+  {
+    "id": "CBC3",
+    "materia": "Física",
+    "creditos": 6,
+    "categoria": "*CBC",
+    "level": -1
+  },
+  {
+    "id": "CBC90",
+    "materia": "Pensamiento Computacional",
+    "creditos": 6,
+    "categoria": "*CBC",
+    "level": -1
+  },
+  {
+    "id": "CBC40",
+    "materia": "Introducción al Pensamiento Científico",
+    "creditos": 4,
+    "categoria": "*CBC",
+    "level": -1
+  },
+  {
+    "id": "CBC",
+    "materia": "Ciclo Básico Común",
+    "creditos": 0,
+    "categoria": "CBC",
+    "level": 0,
+    "correlativas": "CBC66-CBC62-CBC3-CBC90-CBC24-CBC40"
+  },
+  {
+    "id": "AMII",
+    "materia": "Análisis Matemático II",
+    "creditos": 8,
+    "correlativas": "CBC",
+    "categoria": "Materias Obligatorias",
+    "level": 1
+  },
+  {
+    "id": "QB",
+    "materia": "Química Básica",
+    "creditos": 6,
+    "correlativas": "CBC",
+    "categoria": "Materias Obligatorias",
+    "level": 1
+  },
+  {
+    "id": "FSP",
+    "materia": "Física de los Sistemas de Partículas",
+    "creditos": 6,
+    "correlativas": "CBC",
+    "categoria": "Materias Obligatorias",
+    "level": 1
+  },
+  {
+    "id": "IIEE",
+    "materia": "Introducción a la Ingeniería en Energía Eléctrica",
+    "creditos": 4,
+    "correlativas": "CBC",
+    "categoria": "Materias Obligatorias",
+    "level": 1
+  },
+  {
+    "id": "EMC",
+    "materia": "Electricidad, Magnetismo y Calor",
+    "creditos": 6,
+    "correlativas": "AMII-FSP",
+    "categoria": "Materias Obligatorias",
+    "level": 2
+  },
+  {
+    "id": "AL",
+    "materia": "Álgebra Lineal",
+    "creditos": 8,
+    "correlativas": "CBC",
+    "categoria": "Materias Obligatorias",
+    "level": 2
+  },
+  {
+    "id": "ERM",
+    "materia": "Estática y Resistencia de Materiales",
+    "creditos": 6,
+    "correlativas": "AMII-FSP",
+    "categoria": "Materias Obligatorias",
+    "level": 2
+  },
+  {
+    "id": "FSN",
+    "materia": "Física de Sólidos y Nuclear",
+    "creditos": 6,
+    "correlativas": "EMC-QB",
+    "categoria": "Materias Obligatorias",
+    "level": 3
+  },
+  {
+    "id": "MN",
+    "materia": "Modelación Numérica",
+    "creditos": 4,
+    "correlativas": "AMII-AL",
+    "categoria": "Materias Obligatorias",
+    "level": 3
+  },
+  {
+    "id": "PROBA",
+    "materia": "Probabilidad y Estadística",
+    "creditos": 6,
+    "correlativas": "AMII-AL",
+    "categoria": "Materias Obligatorias",
+    "level": 3
+  },
+  {
+    "id": "ELET",
+    "materia": "Electrotecnia",
+    "creditos": 8,
+    "correlativas": "EMC-IIEE",
+    "categoria": "Materias Obligatorias",
+    "level": 3
+  },
+  {
+    "id": "AMIII",
+    "materia": "Análisis Matemático III",
+    "creditos": 6,
+    "correlativas": "AMII-AL",
+    "categoria": "Materias Obligatorias",
+    "level": 4
+  },
+  {
+    "id": "CEM",
+    "materia": "Campos Electromagnéticos",
+    "creditos": 6,
+    "correlativas": "MN-ELET",
+    "categoria": "Materias Obligatorias",
+    "level": 4
+  },
+  {
+    "id": "CSC",
+    "materia": "Circuitos y Sistemas de Control",
+    "creditos": 6,
+    "correlativas": "ELET",
+    "categoria": "Materias Obligatorias",
+    "level": 4
+  },
+  {
+    "id": "ME",
+    "materia": "Medidas Eléctricas",
+    "creditos": 6,
+    "correlativas": "PROBA-ELET",
+    "categoria": "Materias Obligatorias",
+    "level": 4
+  },
+  {
+    "id": "HS",
+    "materia": "Higiene y Seguridad",
+    "creditos": 2,
+    "requiere": 100,
+    "requiereCBC": true,
+    "categoria": "Materias Obligatorias",
+    "level": 5
+  },
+  {
+    "id": "TDMFM",
+    "materia": "Termodinámica, Mecánica de Fluidos y Máquinas",
+    "creditos": 6,
+    "correlativas": "EMC",
+    "categoria": "Materias Obligatorias",
+    "level": 5
+  },
+  {
+    "id": "MELETI",
+    "materia": "Máquinas Eléctricas I",
+    "creditos": 8,
+    "correlativas": "ELET",
+    "categoria": "Materias Obligatorias",
+    "level": 5
+  },
+  {
+    "id": "TME",
+    "materia": "Tecnología de Materiales Eléctricos",
+    "creditos": 6,
+    "correlativas": "FSN-ME",
+    "categoria": "Materias Obligatorias",
+    "level": 5
+  },
+  {
+    "id": "TE",
+    "materia": "Taller de Electrónica",
+    "creditos": 3,
+    "correlativas": "ELET",
+    "categoria": "Materias Obligatorias",
+    "level": 5
+  },
+  {
+    "id": "DEE",
+    "materia": "Diagnósticos Eléctricos y Ensayos",
+    "creditos": 4,
+    "correlativas": "TME",
+    "categoria": "Materias Obligatorias",
+    "level": 6
+  },
+  {
+    "id": "MELETII",
+    "materia": "Máquinas Eléctricas II",
+    "creditos": 8,
+    "correlativas": "CSC-MELETI",
+    "categoria": "Materias Obligatorias",
+    "level": 6
+  },
+  {
+    "id": "MA",
+    "materia": "Mecánica Aplicada",
+    "creditos": 4,
+    "correlativas": "ERM",
+    "categoria": "Materias Obligatorias",
+    "level": 6
+  },
+  {
+    "id": "IBTL",
+    "materia": "Instalaciones de Baja Tensión y Luminotecnia",
+    "creditos": 6,
+    "correlativas": "MELETI-HS",
+    "categoria": "Materias Obligatorias",
+    "level": 6
+  },
+  {
+    "id": "ICD",
+    "materia": "Introducción a la Ciencia de Datos",
+    "creditos": 3,
+    "correlativas": "AL",
+    "categoria": "Materias Obligatorias",
+    "level": 6
+  },
+  {
+    "id": "SEP",
+    "materia": "Sistemas Eléctricos de Potencia",
+    "creditos": 6,
+    "correlativas": "MELETI-CEM",
+    "categoria": "Materias Obligatorias",
+    "level": 7
+  },
+  {
+    "id": "CEEE",
+    "materia": "Conversión Estática de la Energía Eléctrica",
+    "creditos": 6,
+    "correlativas": "TE-AMIII",
+    "categoria": "Materias Obligatorias",
+    "level": 7
+  },
+  {
+    "id": "EEE",
+    "materia": "Economía de la Energía Eléctrica",
+    "creditos": 6,
+    "requiere": 150,
+    "requiereCBC": true,
+    "categoria": "Materias Obligatorias",
+    "level": 7
+  },
+  {
+    "id": "LEP",
+    "materia": "Legislación y Ejercicio Profesional",
+    "creditos": 2,
+    "requiere": 100,
+    "requiereCBC": true,
+    "categoria": "Materias Obligatorias",
+    "level": 7
+  },
+  {
+    "id": "TDEE",
+    "materia": "Transmisión y Distribución de la Energía Eléctrica",
+    "creditos": 6,
+    "correlativas": "MA-DEE",
+    "categoria": "Materias Obligatorias",
+    "level": 8
+  },
+  {
+    "id": "GEE",
+    "materia": "Generación de Energía Eléctrica",
+    "creditos": 8,
+    "correlativas": "TDMFM-MELETI",
+    "categoria": "Materias Obligatorias",
+    "level": 8
+  },
+  {
+    "id": "PEEM",
+    "materia": "Protecciones Eléctricas y Equipos de Maniobra",
+    "creditos": 6,
+    "correlativas": "SEP",
+    "categoria": "Materias Obligatorias",
+    "level": 9
+  },
+  {
+    "id": "ER",
+    "materia": "Energías Renovables",
+    "creditos": 4,
+    "requiere": 120,
+    "requiereCBC": true,
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "UEE",
+    "materia": "Uso Eficiente de la Energía",
+    "creditos": 4,
+    "requiere": 120,
+    "requiereCBC": true,
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "TETE",
+    "materia": "Tecnologías Emergentes en la Transición Energética",
+    "creditos": 4,
+    "requiere": 120,
+    "requiereCBC": true,
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "ITE",
+    "materia": "Introducción a la Transición Energética",
+    "creditos": 4,
+    "requiere": 120,
+    "requiereCBC": true,
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "FCTE",
+    "materia": "Fuentes Convencionales en la Transición Energética",
+    "creditos": 4,
+    "requiere": 120,
+    "requiereCBC": true,
+    "categoria": "Materias Electivas"
+  },
+
+  {
+    "id": "RSP",
+    "materia": "Regulación de Servicios Públicos",
+    "creditos": 4,
+    "requiere": 150,
+    "requiereCBC": true,
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "IO",
+    "materia": "Investigación Operativa",
+    "creditos": 8,
+    "requiere": 150,
+    "requiereCBC": true,
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "AE",
+    "materia": "Accionamientos Eléctricos",
+    "creditos": 4,
+    "correlativas": "MELETII-CEEE",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "MTCE",
+    "materia": "Metrología y Técnicas de Calibración Eléctrica",
+    "creditos": 4,
+    "correlativas": "ME",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "ETD",
+    "materia": "Estaciones Transformadoras y de Distribución",
+    "creditos": 4,
+    "correlativas": "TDEE",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "DSEP",
+    "materia": "Dinámica de Sistemas Eléctricos de Potencia",
+    "creditos": 4,
+    "correlativas": "SEP-MELETII",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "TC",
+    "materia": "Telecontrol y Comunicaciones",
+    "creditos": 4,
+    "correlativas": "SEP",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "PCH",
+    "materia": "Proyecto de Centrales Hidroeléctricas",
+    "creditos": 4,
+    "correlativas": "GEE",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "PCFE",
+    "materia": "Proyecto de Centrales Fotovoltaicas y Eólicas",
+    "creditos": 4,
+    "correlativas": "GEE",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "AAEE",
+    "materia": "Abastecimiento Auxiliar de la Energía Eléctrica",
+    "creditos": 4,
+    "correlativas": "IBTL-CEEE",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "GC",
+    "materia": "Gerenciamiento de la Calidad",
+    "creditos": 4,
+    "correlativas": "EEE",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "EN",
+    "materia": "Energía Nuclear",
+    "creditos": 4,
+    "correlativas": "FSN",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "CONSTEM",
+    "materia": "Construcciones Electromecánicas",
+    "creditos": 4,
+    "correlativas": "DEE-MELETI",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "TIF",
+    "materia": "Trabajo Final Integrador",
+    "creditos": 12,
+    "correlativas": "IBTL",
+    "categoria": "Fin de Carrera (Obligatorio)"
+  }
+]

--- a/src/data/energia-electrica-2020.json
+++ b/src/data/energia-electrica-2020.json
@@ -446,6 +446,8 @@
     "id": "TIF",
     "materia": "Trabajo Final Integrador",
     "creditos": 12,
+     "requiere": 150,
+     "requiereCBC": true,
     "correlativas": "IBTL",
     "categoria": "Fin de Carrera (Obligatorio)"
   }

--- a/src/data/mecanica-2020.json
+++ b/src/data/mecanica-2020.json
@@ -1,0 +1,506 @@
+[
+  {
+    "id": "CBC40",
+    "materia": "Introducción al Pensamiento Científico",
+    "creditos": 4,
+    "categoria": "*CBC",
+    "level": -2
+  },
+  {
+    "id": "CBC90",
+    "materia": "Pensamiento Computacional",
+    "creditos": 6,
+    "categoria": "*CBC",
+    "level": -2
+  },
+  {
+    "id": "CBC66",
+    "materia": "Análisis Matemático A",
+    "creditos": 9,
+    "categoria": "*CBC",
+    "level": -2
+  },
+  {
+    "id": "CBC24",
+    "materia": "Introducción al Conocimiento de la Sociedad y el Estado",
+    "creditos": 4,
+    "categoria": "*CBC",
+    "level": -1
+  },
+  {
+    "id": "CBC3",
+    "materia": "Física",
+    "creditos": 6,
+    "categoria": "*CBC",
+    "level": -1
+  },
+  {
+    "id": "CBC62",
+    "materia": "Álgebra A",
+    "creditos": 9,
+    "categoria": "*CBC",
+    "level": -1
+  },
+  {
+    "id": "CBC",
+    "materia": "Ciclo Básico Común",
+    "creditos": 0,
+    "categoria": "CBC",
+    "level": 0,
+    "correlativas": "CBC66-CBC62-CBC3-CBC90-CBC24-CBC40"
+  },
+  {
+    "id": "AM2",
+    "materia": "Análisis Matemático II",
+    "creditos": 8,
+    "correlativas": "CBC",
+    "categoria": "Materias Obligatorias",
+    "level": 1
+  },
+  {
+    "id": "QB",
+    "materia": "Química Básica",
+    "creditos": 6,
+    "correlativas": "CBC",
+    "categoria": "Materias Obligatorias",
+    "level": 1
+  },
+  {
+    "id": "FSP",
+    "materia": "Física de los Sistemas de Partículas",
+    "creditos": 6,
+    "correlativas": "CBC",
+    "categoria": "Materias Obligatorias",
+    "level": 1
+  },
+  {
+    "id": "IIM",
+    "materia": "Introducción a la Ingeniería Mecánica",
+    "creditos": 4,
+    "correlativas": "CBC",
+    "categoria": "Materias Obligatorias",
+    "level": 1
+  },
+  {
+    "id": "CMM",
+    "materia": "Conocimiento de Materiales Metálicos",
+    "creditos": 6,
+    "correlativas": "QB",
+    "categoria": "Materias Obligatorias",
+    "level": 2
+  },
+  {
+    "id": "DM",
+    "materia": "Diseño Mecánico",
+    "creditos": 4,
+    "correlativas": "IIM",
+    "categoria": "Materias Obligatorias",
+    "level": 2
+  },
+  {
+    "id": "AL",
+    "materia": "Álgebra Lineal",
+    "creditos": 8,
+    "correlativas": "CBC",
+    "categoria": "Materias Obligatorias",
+    "level": 2
+  },
+  {
+    "id": "MCCR",
+    "materia": "Mecánica Clásica del Cuerpo Rígido",
+    "creditos": 6,
+    "correlativas": "FSP",
+    "categoria": "Materias Obligatorias",
+    "level": 2
+  },
+  {
+    "id": "MEC",
+    "materia": "Mecanismos",
+    "creditos": 4,
+    "correlativas": "MCCR",
+    "categoria": "Materias Obligatorias",
+    "level": 3
+  },
+  {
+    "id": "ICD",
+    "materia": "Introducción a la Ciencia de Datos",
+    "creditos": 3,
+    "correlativas": "AL",
+    "categoria": "Materias Obligatorias",
+    "level": 3
+  },
+  {
+    "id": "IMSD",
+    "materia": "Introducción a la Mecánica del Sólido Deformable",
+    "creditos": 6,
+    "correlativas": "MCCR",
+    "categoria": "Materias Obligatorias",
+    "level": 3
+  },
+  {
+    "id": "TD",
+    "materia": "Termodinámica",
+    "creditos": 6,
+    "correlativas": "QB",
+    "categoria": "Materias Obligatorias",
+    "level": 3
+  },
+  {
+    "id": "AM3",
+    "materia": "Análisis Matemático III",
+    "creditos": 6,
+    "correlativas": "AM2",
+    "categoria": "Materias Obligatorias",
+    "level": 3
+  },
+  {
+    "id": "EM",
+    "materia": "Electricidad y Magnetismo",
+    "creditos": 6,
+    "correlativas": "AM2-FSP",
+    "categoria": "Materias Obligatorias",
+    "level": 4
+  },
+  {
+    "id": "MN",
+    "materia": "Modelación Numérica",
+    "creditos": 4,
+    "correlativas": "AM2-AL",
+    "categoria": "Materias Obligatorias",
+    "level": 4
+  },
+  {
+    "id": "CMNM",
+    "materia": "Conocimiento de Materiales No Metálicos",
+    "creditos": 6,
+    "correlativas": "QB",
+    "categoria": "Materias Obligatorias",
+    "level": 4
+  },
+  {
+    "id": "PROB",
+    "materia": "Probabilidad y Estadística",
+    "creditos": 6,
+    "correlativas": "AM2-AL",
+    "categoria": "Materias Obligatorias",
+    "level": 4
+  },
+  {
+    "id": "LEP",
+    "materia": "Legislación y Ejercicio Profesional",
+    "creditos": 2,
+    "requiere": 100,
+    "requiereCBC": true,
+    "categoria": "Materias Obligatorias",
+    "level": 4
+  },
+  {
+    "id": "EI",
+    "materia": "Ensayos Industriales",
+    "creditos": 4,
+    "correlativas": "IMSD-CMM",
+    "categoria": "Materias Obligatorias",
+    "level": 5
+  },
+  {
+    "id": "EG",
+    "materia": "Electrotecnia General",
+    "creditos": 4,
+    "correlativas": "EM",
+    "categoria": "Materias Obligatorias",
+    "level": 5
+  },
+  {
+    "id": "EO",
+    "materia": "Economía y Organización",
+    "creditos": 6,
+    "correlativas": "IIM",
+    "categoria": "Materias Obligatorias",
+    "level": 5
+  },
+  {
+    "id": "TMM",
+    "materia": "Taller de Manufactura Mecánica",
+    "creditos": 4,
+    "correlativas": "CMM",
+    "categoria": "Materias Obligatorias",
+    "level": 5
+  },
+  {
+    "id": "MF",
+    "materia": "Mecánica de Fluidos",
+    "creditos": 6,
+    "correlativas": "IMSD-TD-AM3",
+    "categoria": "Materias Obligatorias",
+    "level": 5
+  },
+  {
+    "id": "TE",
+    "materia": "Taller de Electrónica",
+    "creditos": 3,
+    "correlativas": "EM",
+    "categoria": "Materias Obligatorias",
+    "level": 6
+  },
+  {
+    "id": "PI",
+    "materia": "Proyecto de Instrumentación",
+    "creditos": 4,
+    "correlativas": "EO-PROB-DM",
+    "categoria": "Materias Obligatorias",
+    "level": 6
+  },
+  {
+    "id": "MT",
+    "materia": "Máquinas Térmicas",
+    "creditos": 6,
+    "correlativas": "TD",
+    "categoria": "Materias Obligatorias",
+    "level": 6
+  },
+  {
+    "id": "ISADS",
+    "materia": "Impacto Social, Ambiental y Desarrollo Sustentable",
+    "creditos": 4,
+    "requiere": 100,
+    "requiereCBC": true,
+    "categoria": "Materias Obligatorias",
+    "level": 6
+  },
+  {
+    "id": "TM",
+    "materia": "Tecnología Mecánica",
+    "creditos": 6,
+    "correlativas": "TMM-CMNM",
+    "categoria": "Materias Obligatorias",
+    "level": 6
+  },
+  {
+    "id": "SA",
+    "materia": "Sistemas de Almacenamiento",
+    "creditos": 6,
+    "correlativas": "EI",
+    "categoria": "Materias Obligatorias",
+    "level": 7
+  },
+  {
+    "id": "TCMI",
+    "materia": "Transferencia de Calor y Masa y sus Instalaciones",
+    "creditos": 4,
+    "correlativas": "MF",
+    "categoria": "Materias Obligatorias",
+    "level": 7
+  },
+  {
+    "id": "DFEM",
+    "materia": "Daño y Fractura de Elementos Mecánicos",
+    "creditos": 4,
+    "correlativas": "EI",
+    "categoria": "Materias Obligatorias",
+    "level": 7
+  },
+  {
+    "id": "ME",
+    "materia": "Máquinas Eléctricas",
+    "creditos": 4,
+    "correlativas": "EG",
+    "categoria": "Materias Obligatorias",
+    "level": 7
+  },
+  {
+    "id": "SCA",
+    "materia": "Sistemas de Control y Automatización",
+    "creditos": 6,
+    "correlativas": "TE-MCCR-AM3",
+    "categoria": "Materias Obligatorias",
+    "level": 7
+  },
+  {
+    "id": "TURM",
+    "materia": "Turbomáquinas",
+    "creditos": 4,
+    "correlativas": "MF",
+    "categoria": "Materias Obligatorias",
+    "level": 8
+  },
+  {
+    "id": "PII",
+    "materia": "Proyecto de Instalaciones Industriales",
+    "creditos": 6,
+    "correlativas": "MF-ME",
+    "categoria": "Materias Obligatorias",
+    "level": 8
+  },
+  {
+    "id": "ELEMM",
+    "materia": "Elementos de Máquinas",
+    "creditos": 4,
+    "correlativas": "MEC-IMSD-MN",
+    "categoria": "Materias Obligatorias",
+    "level": 9
+  },
+  {
+    "id": "MC",
+    "materia": "Mantenimiento y Calidad",
+    "creditos": 4,
+    "correlativas": "CMM-EO",
+    "categoria": "Materias Obligatorias",
+    "level": 9
+  },
+  {
+    "id": "PM",
+    "materia": "Proyecto de Máquinas",
+    "creditos": 4,
+    "requiere": 150,
+    "requiereCBC": true,
+    "categoria": "Materias Electivas"
+  },
+
+  {
+    "id": "DMH",
+    "materia": "Diseño de Máquinas Herramientas",
+    "creditos": 4,
+    "requiere": 150,
+    "requiereCBC": true,
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "CNC",
+    "materia": "Control Numérico Computarizado",
+    "creditos": 3,
+    "requiere": 150,
+    "requiereCBC": true,
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "COMB",
+    "materia": "Combustión",
+    "creditos": 3,
+    "requiere": 150,
+    "requiereCBC": true,
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "TF",
+    "materia": "Tecnología del Frío",
+    "creditos": 4,
+    "requiere": 150,
+    "requiereCBC": true,
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "TCA",
+    "materia": "Tecnología del Calor Avanzada",
+    "creditos": 4,
+    "requiere": 150,
+    "requiereCBC": true,
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "TTS",
+    "materia": "Tratamientos Térmicos y de Superficie",
+    "creditos": 4,
+    "requiere": 150,
+    "requiereCBC": true,
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "MMA",
+    "materia": "Materiales Metálicos y sus Aplicaciones",
+    "creditos": 4,
+    "requiere": 150,
+    "requiereCBC": true,
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "ODMO",
+    "materia": "Optimización de Diseños Mecánicos - Opdime",
+    "creditos": 3,
+    "requiere": 150,
+    "requiereCBC": true,
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "IMCF",
+    "materia": "Introducción a la Mecánica Computacional en Fluidos",
+    "creditos": 4,
+    "requiere": 150,
+    "requiereCBC": true,
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "IMCS",
+    "materia": "Introducción a la Mecánica Computacional en Sólidos",
+    "creditos": 4,
+    "requiere": 150,
+    "requiereCBC": true,
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "ROBO",
+    "materia": "Robótica",
+    "creditos": 3,
+    "requiere": 150,
+    "requiereCBC": true,
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "VC",
+    "materia": "Visión por Computadora",
+    "creditos": 4,
+    "requiere": 150,
+    "requiereCBC": true,
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "IBM",
+    "materia": "Introducción a los Biomateriales",
+    "creditos": 4,
+    "requiere": 150,
+    "requiereCBC": true,
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "SSBM",
+    "materia": "Simulación de Sistemas Biomecánicos",
+    "creditos": 3,
+    "requiere": 150,
+    "requiereCBC": true,
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "IIA",
+    "materia": "Introducción a la Inteligencia Artificial",
+    "creditos": 3,
+    "correlativas": "PROB-ICD",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "AD",
+    "materia": "Análisis de Datos",
+    "creditos": 3,
+    "correlativas": "PROB-ICD",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "APM",
+    "materia": "Aprendizaje de Máquina",
+    "creditos": 3,
+    "correlativas": "AD-IIA",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "APMP",
+    "materia": "Aprendizaje de Máquina Profundo",
+    "creditos": 3,
+    "correlativas": "AD-IIA",
+    "categoria": "Materias Electivas"
+  },
+  {
+    "id": "TIF",
+    "materia": "Trabajo Final Integrador",
+    "creditos": 12,
+    "correlativas": "PI-ISADS",
+    "categoria": "Fin de Carrera (Obligatorio)"
+  }
+]


### PR DESCRIPTION
closes #213

Ves algo que agregarle @FdelMazo ?

Una duda, el TIF de energia electrica aparte de tener de correlativa una materia, tiene 150 creditos de correlativas.

Entonces agregamos esos 150 creditos de correlativas?, o lo dejamos como el estandar de los TIF de los planes 2020, que no tienen creditos de correlativas?.