### PR TITLE
Fixed favicon not being displayed (on web browser tab) when running on the development build

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -28,7 +28,7 @@
       integrity="sha512-NJXM8vzWgDcBy9SCUTJXYnNO43sZV3pfLWWZMFTuCtEUIOcznk+AMpH6N3XruxavYfMeMmjrzDMEQ6psRh/6Hw=="
       crossorigin="anonymous"
     />
-    <link rel="icon" type="image/png" href="favicon.png" />
+    <link rel="icon" type="image/png" href="%PUBLIC_URL%/favicon.png" />
     <title>FIUBA Map · fede.dm</title>
   </head>
   <body style="margin: 0">


### PR DESCRIPTION
**Before**. Firefox to the left and Google Chrome to the right:
<img alt="Before. Firefox to the left and Google Chrome to the right." src="https://github.com/user-attachments/assets/67c3180a-79d1-4093-86c9-85d8b0cdb7b4"/>

**After**. Firefox to the left and Google Chrome to the right:
<img alt="After. Firefox to the left and Google Chrome to the right." src="https://github.com/user-attachments/assets/5e9bb50a-8636-4e02-ab4d-bf816e138035"/>