### PR TITLE
added dotted background

### DIFF
--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -189,9 +189,9 @@ const Graph = (userContext: UserType.Context): GraphType.Context => {
 
         // Alinear puntos al grid, dibujando unicamente los puntos
         const startX = Math.floor((worldBounds.left + halfSpacing) / spacing) * spacing + halfSpacing;
-        const endX = Math.ceil((worldBounds.right + halfSpacing) / spacing) * spacing + halfSpacing;
+        const endX = Math.ceil((worldBounds.right + halfSpacing) / spacing) * spacing + halfSpacing - 2*spacing;
         const startY = Math.floor((worldBounds.top + halfSpacing) / spacing) * spacing + halfSpacing;
-        const endY = Math.ceil((worldBounds.bottom + halfSpacing) / spacing) * spacing + halfSpacing;
+        const endY = Math.ceil((worldBounds.bottom + halfSpacing) / spacing) * spacing + halfSpacing - 2*spacing;
 
         ctx.fillStyle = getDotColor();
 

--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -4,7 +4,7 @@ import useResizeObserver from "use-resize-observer";
 import { CARRERAS } from "./carreras";
 import { CREDITOS } from "./constants";
 import Node from "./Node";
-import { COLORS } from "./theme";
+import { COLORS, DOT_PATTERN_CONFIG } from "./theme";
 import { accCreditos, accCreditosNecesarios, accProportion } from "./utils";
 import { UserType } from "./types/User";
 import { GraphType } from "./types/Graph";
@@ -14,6 +14,12 @@ import { NodeType } from "./types/Node";
 const Graph = (userContext: UserType.Context): GraphType.Context => {
   const { user, setUser, logged, saveUserGraph, register } = userContext;
   const { colorMode } = useColorMode();
+
+    // Usar un ref para capturar el colorMode actual dinámicamente
+  const colorModeRef = React.useRef(colorMode);
+  React.useEffect(() => {
+    colorModeRef.current = colorMode;
+  }, [colorMode]);
 
   // Guardamos en el estado que nodo esta clickeado, para mostrarlo en el header
   const [displayedNode, setDisplayedNode] = React.useState("");
@@ -116,26 +122,88 @@ const Graph = (userContext: UserType.Context): GraphType.Context => {
     // Le pongo una key al network para poder compararla contra la key del graph
     network.key = user.carrera.id;
 
-    // Por mas que me encante este efecto, le agrega mucho tiempo de carga a la pagina antes de abrir
-    // Lo dejo comentado nada mas por lo mucho que me gusta
-    // https://stackoverflow.com/a/72950605/10728610
-    // https://www.seancdavis.com/posts/mutlicolored-dotted-grid-canvas/
-    // https://github.com/open-source-labs/Svelvet/blob/main/src/lib/containers/Background/Background.svelte
-    // network.on("beforeDrawing", function (ctx) {
-    //   var width = ctx.canvas.clientWidth;
-    //   var height = ctx.canvas.clientHeight;
-    //   var spacing = 24;
-    //   var gridExtentFactor = 1.5;
-    //   ctx.fillStyle = "darkgray"
+    const getDotColor = () => {
+      const isDark = colorModeRef.current === "dark";
+      return DOT_PATTERN_CONFIG.colors[isDark ? "dark" : "light"];
+    };
 
-    //   for (var x = -width * gridExtentFactor; x <= width * gridExtentFactor; x += spacing) {
-    //     for (var y = -height * gridExtentFactor; y <= height * gridExtentFactor; y += spacing) {
-    //       ctx.beginPath();
-    //       ctx.arc(x, y, 1, 0, 2 * Math.PI, false);
-    //       ctx.fill();
-    //     }
-    //   }
-    // });
+    const patternCache : {
+      pattern: CanvasPattern | null;
+      isDark: boolean | null
+    } = { pattern: null, isDark: null };
+
+    const createDotPattern: (ctx: CanvasRenderingContext2D) => CanvasPattern = (ctx: CanvasRenderingContext2D) => {
+      const { spacing, radius } = DOT_PATTERN_CONFIG;
+      const patternCanvas = document.createElement("canvas");
+      patternCanvas.width = spacing;
+      patternCanvas.height = spacing;
+
+      const patternCtx: CanvasRenderingContext2D | null = patternCanvas.getContext("2d", { alpha: true });
+
+      if (!patternCtx) {
+        throw new Error("Could not create pattern context");
+      }
+
+      patternCtx.fillStyle = getDotColor();
+      patternCtx.beginPath();
+      patternCtx.arc(spacing / 2, spacing / 2, radius, 0, Math.PI * 2);
+      patternCtx.fill();
+
+      const return_pattern = ctx.createPattern(patternCanvas, "repeat");
+
+      if (!return_pattern) {
+        throw new Error("Could not create pattern");
+      }
+
+      return return_pattern;
+    };
+
+    // Patrón híbrido: patrón para zoom out, dibujo directo para zoom in
+    // @ts-expect-error - la librería está mal tipada, sí recibe ctx
+    network.on("beforeDrawing", function (ctx: CanvasRenderingContext2D) { 
+      const isDark = colorModeRef.current === "dark";
+      const zoom = network.getScale();
+      const { width, height } = ctx.canvas;
+      const { spacing, radius, zoomThreshold, infiniteBounds } = DOT_PATTERN_CONFIG;
+      const halfSpacing = spacing / 2;
+
+      if (zoom < zoomThreshold) {
+        // ZOOM OUT: patrón repetido cacheado
+        if (patternCache.isDark !== isDark || !patternCache.pattern) {
+          patternCache.pattern = createDotPattern(ctx);
+          patternCache.isDark = isDark;
+        }
+        ctx.fillStyle = patternCache.pattern;
+        ctx.fillRect(-infiniteBounds, -infiniteBounds, infiniteBounds * 2, infiniteBounds * 2);
+      } else {
+        // ZOOM IN: dibujo directo en el canvas los puntos, pero unicamente los que si sean visibles.
+        const viewPos = network.getViewPosition();
+
+        // Calcular viewport en coordenadas del mundo
+        const worldBounds = {
+          left: viewPos.x - width / 2 / zoom,
+          right: viewPos.x + width / 2 / zoom,
+          top: viewPos.y - height / 2 / zoom,
+          bottom: viewPos.y + height / 2 / zoom
+        };
+
+        // Alinear puntos al grid, dibujando unicamente los puntos
+        const startX = Math.floor((worldBounds.left + halfSpacing) / spacing) * spacing + halfSpacing;
+        const endX = Math.ceil((worldBounds.right + halfSpacing) / spacing) * spacing + halfSpacing;
+        const startY = Math.floor((worldBounds.top + halfSpacing) / spacing) * spacing + halfSpacing;
+        const endY = Math.ceil((worldBounds.bottom + halfSpacing) / spacing) * spacing + halfSpacing;
+
+        ctx.fillStyle = getDotColor();
+
+        for (let x = startX; x <= endX; x += spacing) {
+          for (let y = startY; y <= endY; y += spacing) {
+            ctx.beginPath();
+            ctx.arc(x, y, radius, 0, Math.PI * 2);
+            ctx.fill();
+          }
+        }
+      }
+    });
 
     setNetwork(network);
   };

--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -195,12 +195,16 @@ const Graph = (userContext: UserType.Context): GraphType.Context => {
 
         ctx.fillStyle = getDotColor();
 
+        const rowPath = new Path2D();
+        for (let y = startY; y <= endY; y += spacing) {
+          rowPath.arc(0, y - startY, radius, 0, Math.PI * 2);
+        }
+
         for (let x = startX; x <= endX; x += spacing) {
-          for (let y = startY; y <= endY; y += spacing) {
-            ctx.beginPath();
-            ctx.arc(x, y, radius, 0, Math.PI * 2);
-            ctx.fill();
-          }
+          ctx.save();
+          ctx.translate(x, startY);
+          ctx.fill(rowPath);
+          ctx.restore();
         }
       }
     });

--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -122,17 +122,23 @@ const Graph = (userContext: UserType.Context): GraphType.Context => {
     // Le pongo una key al network para poder compararla contra la key del graph
     network.key = user.carrera.id;
 
-    const getDotColor = () => {
-      const isDark = colorModeRef.current === "dark";
+    // Funcion para obtener el color del punteado del fondo.
+    const getDotColor = (isDark: boolean) => {
       return DOT_PATTERN_CONFIG.colors[isDark ? "dark" : "light"];
     };
 
-    const patternCache : {
-      pattern: CanvasPattern | null;
-      isDark: boolean | null
-    } = { pattern: null, isDark: null };
+    // Estructura donde se van a guardar los patrones, para poder crearlos una sola vez.
+    const patternCache: {
+      light: CanvasPattern | null;
+      dark: CanvasPattern | null;
+    } = { light: null, dark: null };
 
-    const createDotPattern: (ctx: CanvasRenderingContext2D) => CanvasPattern| null = (ctx: CanvasRenderingContext2D) => {
+    // Crea un CanvasPattern, usado como mosaico para el fondo del mapa.
+    // Renderiza un canvas con un único punto en el centro.
+    const createDotPattern = (
+      ctx: CanvasRenderingContext2D,
+      isDark: boolean,
+    ): CanvasPattern | null => {
       const { spacing, radius } = DOT_PATTERN_CONFIG;
       const patternCanvas = document.createElement("canvas");
       patternCanvas.width = spacing;
@@ -144,45 +150,57 @@ const Graph = (userContext: UserType.Context): GraphType.Context => {
         return null;
       }
 
-      patternCtx.fillStyle = getDotColor();
+      patternCtx.fillStyle = getDotColor(isDark);
       patternCtx.beginPath();
       patternCtx.arc(spacing / 2, spacing / 2, radius, 0, Math.PI * 2);
       patternCtx.fill();
 
       const return_pattern = ctx.createPattern(patternCanvas, "repeat");
 
-      if (!return_pattern) {
-        throw new Error("Could not create pattern");
-      }
-
       return return_pattern;
     };
 
-    // Patrón híbrido: patrón para zoom out, dibujo directo para zoom in
+    // Pre-crear ambos patrones al inicio de la red para que esten en cache.
+    const bootstrapCanvas = document.createElement("canvas");
+    const bootstrapCtx = bootstrapCanvas.getContext("2d", { alpha: true });
+    if (bootstrapCtx) {
+      patternCache.light = createDotPattern(bootstrapCtx, false);
+      patternCache.dark = createDotPattern(bootstrapCtx, true);
+    }
+
+    // Evento donde se dibuja el fondo con el patrón de puntos.
+    // Internamente se hace de 2 modos distintos, utilizando el CanvasPattern cacheado para zooms pequeños,
+    // y dibujando manualmente los puntos para zooms grandes (para evitar que se vean borrosos).
     // @ts-expect-error - la librería está mal tipada, sí recibe ctx
     network.on("beforeDrawing", function (ctx: CanvasRenderingContext2D) { 
       const isDark = colorModeRef.current === "dark";
       const zoom = network.getScale();
-      const { width, height } = ctx.canvas;
       const { spacing, radius, zoomThreshold, infiniteBounds } = DOT_PATTERN_CONFIG;
-      const halfSpacing = spacing / 2;
 
+      // Se chequea si en nivel de zoom actual es muy alto o muy bajo (usando como limite el threshold definido en la configuración).
       if (zoom < zoomThreshold) {
-        // ZOOM OUT: patrón repetido cacheado
-        if (patternCache.isDark !== isDark || !patternCache.pattern) {
-          const dot_pattern = createDotPattern(ctx);
-          if (!dot_pattern) {
-            return null;
-          }
+        // ZOOM OUT: patrón repetido cacheado.
+        // Utiliza el canvas pattern pre-renderizado para llenar el fondo.
+        // El patrón se dibuja en un área grande centrada en el viewport para asegurar que siempre haya puntos visibles, incluso al mover la vista.
+        // Este metodo no se puede utilizar cuando hay mucho zoom, porque el patrón se escala y se ve borroso. Por eso, para zooms grandes, se dibujan los puntos manualmente.
 
-          patternCache.pattern = dot_pattern;
-          patternCache.isDark = isDark;
+        // Obtener el patrón correspondiente al modo de color actual
+        const canvas_pattern_to_use = isDark ? patternCache.dark : patternCache.light;
+        if (!canvas_pattern_to_use) {
+          return null;
         }
-        ctx.fillStyle = patternCache.pattern;
+
+        ctx.fillStyle = canvas_pattern_to_use;
         ctx.fillRect(-infiniteBounds, -infiniteBounds, infiniteBounds * 2, infiniteBounds * 2);
       } else {
         // ZOOM IN: dibujo directo en el canvas los puntos, pero unicamente los que si sean visibles.
+        // Para evitar que se vean borrosos, se dibujan círculos individuales en las posiciones correspondientes a los puntos del patrón, en lugar de usar un CanvasPattern escalado.
+        // Este metodo no se usa cuando esta muy alejado porque es muy ineficiente dibujar cada punto individualmente, pero para zooms cercanos, mantiene los puntos nítidos y definidos.
+
         const viewPos = network.getViewPosition();
+        const { width, height } = ctx.canvas;
+        
+        const halfSpacing = spacing / 2;
 
         // Calcular viewport en coordenadas del mundo
         // Extendemos los bounds por el radius de los puntos para asegurar que
@@ -194,19 +212,22 @@ const Graph = (userContext: UserType.Context): GraphType.Context => {
           bottom: viewPos.y + height / 2 / zoom + radius / zoom
         };
 
-        // Alinear puntos al grid, dibujando unicamente los puntos
+        // Alinear puntos al grid, dibujando unicamente los puntos que serían visibles en el viewport actual
         const startX = Math.floor((worldBounds.left + halfSpacing) / spacing) * spacing + halfSpacing;
         const endX = Math.ceil((worldBounds.right + halfSpacing) / spacing) * spacing + halfSpacing - 2*spacing;
         const startY = Math.floor((worldBounds.top + halfSpacing) / spacing) * spacing + halfSpacing;
         const endY = Math.ceil((worldBounds.bottom + halfSpacing) / spacing) * spacing + halfSpacing - 2*spacing;
 
-        ctx.fillStyle = getDotColor();
+        ctx.fillStyle = getDotColor(isDark);
 
+        // Genera un Path2D, para generar una fila de puntos.
         const rowPath = new Path2D();
         for (let y = startY; y <= endY; y += spacing) {
           rowPath.arc(0, y - startY, radius, 0, Math.PI * 2);
         }
 
+        // Utiliza la fila de puntos generada recien, para ir moviendola, y dibujando cada fila subsiguiente.
+        // Esto resulta mucho más rapido que dibujar cada uno de los puntos individualmente.
         for (let x = startX; x <= endX; x += spacing) {
           ctx.save();
           ctx.translate(x, startY);

--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -180,11 +180,13 @@ const Graph = (userContext: UserType.Context): GraphType.Context => {
         const viewPos = network.getViewPosition();
 
         // Calcular viewport en coordenadas del mundo
+        // Extendemos los bounds por el radius de los puntos para asegurar que
+        // los puntos que están parcialmente en el viewport se rendericen
         const worldBounds = {
-          left: viewPos.x - width / 2 / zoom,
-          right: viewPos.x + width / 2 / zoom,
-          top: viewPos.y - height / 2 / zoom,
-          bottom: viewPos.y + height / 2 / zoom
+          left: viewPos.x - width / 2 / zoom - radius / zoom,
+          right: viewPos.x + width / 2 / zoom + radius / zoom,
+          top: viewPos.y - height / 2 / zoom - radius / zoom,
+          bottom: viewPos.y + height / 2 / zoom + radius / zoom
         };
 
         // Alinear puntos al grid, dibujando unicamente los puntos

--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -132,7 +132,7 @@ const Graph = (userContext: UserType.Context): GraphType.Context => {
       isDark: boolean | null
     } = { pattern: null, isDark: null };
 
-    const createDotPattern: (ctx: CanvasRenderingContext2D) => CanvasPattern = (ctx: CanvasRenderingContext2D) => {
+    const createDotPattern: (ctx: CanvasRenderingContext2D) => CanvasPattern| null = (ctx: CanvasRenderingContext2D) => {
       const { spacing, radius } = DOT_PATTERN_CONFIG;
       const patternCanvas = document.createElement("canvas");
       patternCanvas.width = spacing;
@@ -141,7 +141,7 @@ const Graph = (userContext: UserType.Context): GraphType.Context => {
       const patternCtx: CanvasRenderingContext2D | null = patternCanvas.getContext("2d", { alpha: true });
 
       if (!patternCtx) {
-        throw new Error("Could not create pattern context");
+        return null;
       }
 
       patternCtx.fillStyle = getDotColor();
@@ -170,7 +170,12 @@ const Graph = (userContext: UserType.Context): GraphType.Context => {
       if (zoom < zoomThreshold) {
         // ZOOM OUT: patrón repetido cacheado
         if (patternCache.isDark !== isDark || !patternCache.pattern) {
-          patternCache.pattern = createDotPattern(ctx);
+          const dot_pattern = createDotPattern(ctx);
+          if (!dot_pattern) {
+            return null;
+          }
+
+          patternCache.pattern = dot_pattern;
           patternCache.isDark = isDark;
         }
         ctx.fillStyle = patternCache.pattern;

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -76,6 +76,19 @@ export const COLORS = {
   },
 };
 
+export const DOT_PATTERN_CONFIG = {
+  spacing: 20,              // Distance between dots in pixels (at zoom level 1)
+  radius: 1,                // Radius of each dot in pixels (at zoom level 1)
+  zoomThreshold: 1,         // Zoom level where the pattern stops being a CanvasPattern, and starts being drawn manually
+                            // This is because at zoom > 1, the pattern becomes blurry.
+                            // Drawing manually mantains pixel-perfect dots, but is more expensive than CanvasPattern.
+  infiniteBounds: 50000,    // The CanvasPattern will be drawn in a square of size infiniteBounds centered on the viewport.
+  colors: {                 // Colors for the dot pattern, depending on the color mode
+    dark: "#3a3a3a",  
+    light: "#d0d5dd",
+  },
+};
+
 const config = {
   initialColorMode: "system",
 };

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -77,7 +77,7 @@ export const COLORS = {
 };
 
 export const DOT_PATTERN_CONFIG = {
-  spacing: 20,              // Distance between dots in pixels (at zoom level 1)
+  spacing: 25,              // Distance between dots in pixels (at zoom level 1)
   radius: 1,                // Radius of each dot in pixels (at zoom level 1)
   zoomThreshold: 1,         // Zoom level where the pattern stops being a CanvasPattern, and starts being drawn manually
                             // This is because at zoom > 1, the pattern becomes blurry.

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,4 +1,4 @@
-import { extendTheme } from "@chakra-ui/react";
+import { extendTheme, LightMode } from "@chakra-ui/react";
 
 export const COLORS = {
   // https://nipponcolors.com/
@@ -84,8 +84,8 @@ export const DOT_PATTERN_CONFIG = {
                             // Drawing manually mantains pixel-perfect dots, but is more expensive than CanvasPattern.
   infiniteBounds: 50000,    // The CanvasPattern will be drawn in a square of size infiniteBounds centered on the viewport.
   colors: {                 // Colors for the dot pattern, depending on the color mode
-    dark: "#3a3a3a",  
-    light: "#d0d5dd",
+    dark: "#4a4a4a",  
+    light: "#929292",
   },
 };
 


### PR DESCRIPTION
Agrega un fondo punteado al mapa.

Cuando el zoom es menor a 1, utiliza un CanvasPattern, que repite un canvas infinitamente, con coste casi nulo.
Cuando el zoom es superior a 1, el CanvasPattern empieza a blurrearse, así que decidí reusar el método de dibujar cada punto de a uno, pero con la modificación de únicamente dibujar los puntos que sean visibles. Reduciendo los puntos a dibujar de 30k (en la implementación comentada) a 3k como máximo.

Igualmente, el threshold es configurable, para capaz esperar a mayor zoom para dibujar los puntos pixel perfect, y tolerar cierta interpolación.